### PR TITLE
Lessen_dissolve_item_trap_potential

### DIFF
--- a/roguelike/traps.cpp
+++ b/roguelike/traps.cpp
@@ -1021,7 +1021,7 @@ void Player::loseAcid() {
     for(i=0; i<MAXWEAR; i++) {
         if(ready[i]) {
             if( !ready[i]->flagIsSet(O_RESIST_DISOLVE) &&
-                (mrand(1,100) <= 5 - abs(ready[i]->getAdjustment()))
+                (mrand(1,100) <= 3 - abs(ready[i]->getAdjustment()))
             ) {
                 if(ready[i]->flagIsSet(O_NO_PREFIX)) {
                     printColor("^r%s was dissolved by acid!\n", ready[i]->getCName());
@@ -1045,7 +1045,7 @@ void Player::loseAcid() {
     for( it = objects.begin() ; it != objects.end() ; ) {
         object = (*it++);
         if( !object->flagIsSet(O_RESIST_DISOLVE) &&
-            (mrand(1,100) <= 5 - abs(object->getAdjustment())))
+            (mrand(1,100) <= 3 - abs(object->getAdjustment() ) ))
         {
             if(object->flagIsSet(O_NO_PREFIX)) {
                 printColor("^r%s is dissolved by acid!\n", object->getCName());
@@ -1057,6 +1057,8 @@ void Player::loseAcid() {
             delObj(object, true, false, true, false);
             delete object;
         }
+        if (mrand(1,100) <= 20)
+            break;
     }
     checkDarkness();
 }


### PR DESCRIPTION
Changing it from 5% chance per item to 3% per item, and also adding in a 20% chance to break out of the for loop when checking inventory.
None of this even triggers if the player saves vs traps, so it's rare. But I think it needs to be less harsh than it currently is anyway, even on a failed save.