### PR TITLE
Raise_level_req_for_Resurrect-Bloodfusiion

### DIFF
--- a/combat/die.cpp
+++ b/combat/die.cpp
@@ -1880,6 +1880,7 @@ void Player::die(DeathType dt) {
         logn("log.death", "%s was choked to death by deadly underdark moss.\n", getCName());
         sprintf(deathStr, "### Sadly, %s was choked to death by deadly underdark moss.", getCName());
         death = "deadly underdark moss";
+        break;
     case PIERCER:
         sprintf(deathStr, "### Sadly, %s was impaled to death by a piercer.", getCName());
         logn("log.death", "%s was killed by a piercer.\n", getCName());
@@ -2053,6 +2054,7 @@ void Player::die(DeathType dt) {
     //  print(deathStr);
     //}
     broadcast(deathStr);
+
 
 
     oldxp = experience;

--- a/magic/divine/healmagic.cpp
+++ b/magic/divine/healmagic.cpp
@@ -1065,8 +1065,8 @@ int splResurrect(Creature* player, cmd* cmnd, SpellData* spellData) {
             player->print("You do not know that spell.\n");
             return(0);
         }
-        if(player->getLevel() < 19) {
-            player->print("You are not high enough level to cast that spell.\n");
+        if(player->getLevel() < MAXALVL) {
+            player->print("You are not yet revered enough by Ceris to cast that spell.\n");
             return(0);
         }
         if(player->getAdjustedAlignment() != NEUTRAL) {
@@ -1096,8 +1096,8 @@ int splBloodfusion(Creature* player, cmd* cmnd, SpellData* spellData) {
             player->print("You do not know that spell.\n");
             return(0);
         }
-        if(player->getLevel() < 22) {
-            player->print("You are not high enough level to cast that spell.\n");
+        if(player->getLevel() < MAXALVL) {
+            player->print("You are not yet vile enough in the eyes of Aramon to cast that spell.\n");
             return(0);
         }
         if(player->getAdjustedAlignment() != BLOODRED) {

--- a/magic/divine/healmagic.cpp
+++ b/magic/divine/healmagic.cpp
@@ -932,6 +932,11 @@ int doRes(Creature* caster, cmd* cmnd, bool res) {
 
 
     if(!caster->isDm()) {
+    	// If caster is max available level, they can res/fuse anybody. Otherwise, target must be lower level than caster.
+        if((caster->getLevel() <= target->getLevel()) && caster->getLevel() != MAXALVL) {
+        	caster->print("You must be higher level than %s to %s %s.\n",target->getCName(), res ? "resurrect" : "bloodfuse", target->himHer());
+        	return(0);
+        }
         if(target->getLocation() != target->getLimboRoom()) {
             caster->print("%s is not in limbo! How can you %s %s?\n",
                 target->getCName(), res ? "resurrect" : "bloodfuse", target->himHer());
@@ -1065,8 +1070,8 @@ int splResurrect(Creature* player, cmd* cmnd, SpellData* spellData) {
             player->print("You do not know that spell.\n");
             return(0);
         }
-        if(player->getLevel() < MAXALVL) {
-            player->print("You are not yet revered enough by Ceris to cast that spell.\n");
+        if(player->getLevel() < 30) {
+            player->print("You are not yet revered enough by Ceris to cast that spell. You must be level 30.\n");
             return(0);
         }
         if(player->getAdjustedAlignment() != NEUTRAL) {
@@ -1096,8 +1101,8 @@ int splBloodfusion(Creature* player, cmd* cmnd, SpellData* spellData) {
             player->print("You do not know that spell.\n");
             return(0);
         }
-        if(player->getLevel() < MAXALVL) {
-            player->print("You are not yet vile enough in the eyes of Aramon to cast that spell.\n");
+        if(player->getLevel() < 30) {
+            player->print("You are not yet vile enough in the eyes of Aramon to cast that spell. You must be level 30.\n");
             return(0);
         }
         if(player->getAdjustedAlignment() != BLOODRED) {

--- a/players/levelGain.cpp
+++ b/players/levelGain.cpp
@@ -416,7 +416,7 @@ void Player::upLevel() {
 
 
     if( cClass == CreatureClass::CLERIC &&
-        level >= MAXALVL &&
+        level >= 30 &&
         deity == CERIS &&
         !spellIsKnown(S_RESURRECT)
     ) {
@@ -426,7 +426,7 @@ void Player::upLevel() {
 
     if( cClass == CreatureClass::CLERIC &&
         !hasSecondClass() &&
-        level >= MAXALVL &&
+        level >= 30 &&
         deity == ARAMON &&
         !spellIsKnown(S_BLOODFUSION)
     ) {

--- a/players/levelGain.cpp
+++ b/players/levelGain.cpp
@@ -416,7 +416,7 @@ void Player::upLevel() {
 
 
     if( cClass == CreatureClass::CLERIC &&
-        level >= 19 &&
+        level >= MAXALVL &&
         deity == CERIS &&
         !spellIsKnown(S_RESURRECT)
     ) {
@@ -426,7 +426,7 @@ void Player::upLevel() {
 
     if( cClass == CreatureClass::CLERIC &&
         !hasSecondClass() &&
-        level >= 22 &&
+        level >= MAXALVL &&
         deity == ARAMON &&
         !spellIsKnown(S_BLOODFUSION)
     ) {


### PR DESCRIPTION
Spell was originally designed for a 30 level system. Res/Bloodf slaves was an unforeseen consequence. Going back i wouldn't even have put this in. lol..No other changes to it, but i'd like them to level to 40 if they going to res/bloodf slave. Very powerful spell. I set it to MAXALVL if we ever increase from 40 going forward.