### PR TITLE
Update server.cpp

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -802,7 +802,7 @@ void Server::updateRandom(long t) {
         if(!monster->flagIsSet(M_CUSTOM))
             monster->validateAc();
 
-        if((monster->flagIsSet(M_NIGHT_ONLY) && isDay()) ||(monster->flagIsSet(M_DAY_ONLY) && !isDay())) {
+        if( (monster->flagIsSet(M_NIGHT_ONLY) && isDay()) ||(monster->flagIsSet(M_DAY_ONLY) && !isDay()) && monster->inCombat(false)) {
             free_crt(monster);
             continue;
         }


### PR DESCRIPTION
BUG FIX: Make it so mobs set to Night/Day only do not wander if they are engaged in combat.

This sucks if a mob is steal aggro and has stolen somebody's shit and just wanders off when the sun comes up.