### PR TITLE
Update die.cpp

### DIFF
--- a/combat/die.cpp
+++ b/combat/die.cpp
@@ -350,6 +350,7 @@ void Player::dieToMonster(Monster *killer) {
 
     broadcast("### Sadly, %s was killed by %1N.", getCName(), killer);
     killer->clearEnemy(this);
+    clearTarget();
     clearAsEnemy();
     gServer->clearAsEnemy(this);
     loseExperience(killer);


### PR DESCRIPTION
Target not clearing on death. As result, players go back and hit "kill" to attack something else, and wind up attacking the old target. Fix requested by new player.