### PR TITLE
Update_armor_spell_and_starting_spell_changes

### DIFF
--- a/combat/attack.cpp
+++ b/combat/attack.cpp
@@ -1141,18 +1141,23 @@ void Creature::modifyDamage(Creature* enemy, int dmgType, Damage& attackDamage, 
         EffectInfo* armorEffect = getEffect("armor");
         vHp = armorEffect->getStrength();
 
-        if(vHp <= 0 || attackDamage.get() <= 0)
-            vHp=0; //shouldn't happen, but check anyway.
+      //  if(vHp <= 0 || attackDamage.get() <= 0)
+      //    vHp=0; //shouldn't happen, but check anyway.
+
+        vHp = MAX(0,vHp); 
 
         vHp -= (int)attackDamage.get();
+
         if(vHp <= 0) {
             removeEffect("armor");
             if(player) {
-                printColor("^y^#Your magical armorEffect has been dispelled.\n");
+                printColor("^y^#Your magical armor has been dispelled.\n");
                 player->computeAC();
             }
-            broadcast(getSock(), getRoomParent(), "%M's magical armorEffect has been dispelled.", this);
+            broadcast(getSock(), getRoomParent(), "%M's magical armor has been dispelled.", this);
         } else {
+           // if ((int)attackDamage.get() > 0)    
+           //     printColor("^BYour magical armor has ^C%d^B strength remaining.\n", vHp);
             armorEffect->setStrength(vHp);
         }
     }

--- a/effects/effects.cpp
+++ b/effects/effects.cpp
@@ -875,6 +875,10 @@ bstring Effects::getEffectsString(const Creature* viewer) {
         else
             effStr << timeStr(effectInfo->duration);
 
+        if( !viewer->isStaff() && effectInfo->getName() == "armor") 
+            effStr << "  ^WStrength:^x " << effectInfo->getStrength();
+    
+
         if(viewer->isStaff()) {
 //          if(!effectInfo->getBaseEffect().empty())
 //              effStr << " Base(" << effectInfo->getBaseEffect() << ")";

--- a/players/player.cpp
+++ b/players/player.cpp
@@ -235,8 +235,13 @@ void Player::init() {
     if(cClass == CreatureClass::THIEF && cClass2 == CreatureClass::MAGE)
         addPermEffect("detect-magic");
 
-    if((cClass == CreatureClass::MAGE || cClass2 == CreatureClass::MAGE) && level >= 7)
+    if(level >=1 && (cClass == CreatureClass::LICH || cClass == CreatureClass::MAGE) ) {
         learnSpell(S_ARMOR);
+        learnSpell(S_MAGIC_MISSILE);
+    }
+
+    if(level >= 1 && (cClass == CreatureClass::CLERIC || cClass == CreatureClass::DRUID) )
+        learnSpell(S_VIGOR);
 
     if(cClass == CreatureClass::CLERIC && deity == CERIS && level >= 13)
         learnSpell(S_REJUVENATE);
@@ -526,7 +531,7 @@ void Player::init() {
     killDarkmetal();
 
     if(weaponTrains != 0)
-        print("You have %d weapon train(s) available!\n", weaponTrains);
+        print("You have %d weapon train(s) available! (^YHELP WEAPONS^x)\n", weaponTrains);
 
 
     computeInterest(t, true);

--- a/server/login.cpp
+++ b/server/login.cpp
@@ -800,6 +800,10 @@ void Create::addStartingWeapon(Player* player, const bstring& weapon) {
         Create::addStartingItem(player, "tut", 30, false);
     else if(weapon == "thrown")
         Create::addStartingItem(player, "tut", 31, false);
+     else if(weapon == "knife")
+        Create::addStartingItem(player, "tut", 43, false);
+     else if(weapon == "sling")
+        Create::addStartingItem(player, "tut", 44, false);
 }
 
 


### PR DESCRIPTION
Updated armor spell. It was crapping out after one hit the way it was before.
It will now work as intended. Details are commented in the code. Players can see the remaining strength of their armor spell in the "effects" command.

Mages (as their first class) and liches now start with the armor and magic-missile spells.

Also set up clerics and druids to always start with the vigor spell.

Also added starting weapons for the recently added knife and sling skills.