### PR TITLE
nerf acid trap

### DIFF
--- a/roguelike/traps.cpp
+++ b/roguelike/traps.cpp
@@ -674,6 +674,7 @@ int Player::doCheckTraps(UniqueRoom* room) {
         broadcast(getSock(), getRoomParent(), "%M is immersed in acid!", this);
         trapDamage.set(Random::get(20,30));
 
+
         if(chkSave(DEA, this, 0)) {
             trapDamage.set(trapDamage.get() / 2);
             print("The acid doesn't totally cover you.\n");
@@ -1038,9 +1039,9 @@ void Player::loseAcid() {
                 (Random::get(1,100) <= 3 - abs(ready[i]->getAdjustment()))
             ) {
                 if(ready[i]->flagIsSet(O_NO_PREFIX)) {
-                    printColor("^r%s was dissolved by acid!\n", ready[i]->getCName());
+                    printColor("^y%s %s dissolved by acid!\n", ready[i]->getCName(), ready[i]->flagIsSet(O_SOME_PREFIX) ? "were":"was");
                 } else {
-                    printColor("^rYour %s was dissolved by acid!\n", ready[i]->getCName());
+                    printColor("^yYour %s %s dissolved by acid!\n", ready[i]->getCName(),ready[i]->flagIsSet(O_SOME_PREFIX) ? "were":"was");
                 }
 
                 logn("log.dissolve", "%s(L%d) lost %s to acid trap in room %s.\n",
@@ -1055,7 +1056,7 @@ void Player::loseAcid() {
     computeAttackPower();
 
     // 10% chance to attempt dissolving inventory possessions, reduced by higher dexterity bonus.
-    if ( Random::get(1,100) <= MAX(1,(10 - bonus(dexterity.getCur()))) )
+    if (Random::get(1,100) <= MAX(1,(10 - bonus(dexterity.getCur()))) )
     {
         ObjectSet::iterator it;
         for( it = objects.begin() ; it != objects.end() ; ) {
@@ -1068,9 +1069,9 @@ void Player::loseAcid() {
                 (Random::get(1,100) <= (4 - abs(object->getAdjustment() )) ))
             {
                 if(object->flagIsSet(O_NO_PREFIX)) {
-                    printColor("^y%s is dissolved by acid!\n", object->getCName());
+                    printColor("^y%s %s dissolved by acid!\n", object->getCName(), object->flagIsSet(O_SOME_PREFIX) ? "were":"was");
                 } else {
-                    printColor("^yYour %s is dissolved by acid!\n", object->getCName());
+                    printColor("^yYour %s %s dissolved by acid!\n", object->getCName(), object->flagIsSet(O_SOME_PREFIX) ? "were":"was");
                 }
                 logn("log.dissolve", "%s(L%d) lost %s to acid trap in room %s.\n",
                         getCName(), level, object->getCName(), getRoomParent()->fullName().c_str());

--- a/roguelike/traps.cpp
+++ b/roguelike/traps.cpp
@@ -1043,7 +1043,7 @@ void Player::loseAcid() {
                     printColor("^rYour %s was dissolved by acid!\n", ready[i]->getCName());
                 }
 
-                logn("log.dissolve", "%s(L%d) lost %s to acid in room %s.\n",
+                logn("log.dissolve", "%s(L%d) lost %s to acid trap in room %s.\n",
                         getCName(), level, ready[i]->getCName(), getRoomParent()->fullName().c_str());
                 unequip(i+1, UNEQUIP_DELETE);
             }
@@ -1054,25 +1054,34 @@ void Player::loseAcid() {
     computeAC();
     computeAttackPower();
 
-    // Remove and possibly dissolve possessions
-    ObjectSet::iterator it;
-    for( it = objects.begin() ; it != objects.end() ; ) {
-        object = (*it++);
-        if( !object->flagIsSet(O_RESIST_DISOLVE) &&
-            (Random::get(1,100) <= 3 - abs(object->getAdjustment() ) ))
-        {
-            if(object->flagIsSet(O_NO_PREFIX)) {
-                printColor("^r%s is dissolved by acid!\n", object->getCName());
-            } else {
-                printColor("^rYour %s is dissolved by acid!\n", object->getCName());
+    // 10% chance to attempt dissolving inventory possessions, reduced by higher dexterity bonus.
+    if ( Random:get(1,100) <= MAX(1,(10 - bonus(player->dexterity.getCur()))) )
+    {
+        ObjectSet::iterator it;
+        for( it = objects.begin() ; it != objects.end() ; ) {
+            object = (*it++);
+            // Bags have a much much rarer chance to attempt dissolve. (approx 25/10000 == .25%)
+            if(object->getType() == ObjectType::CONTAINER && (Random:get(1,10000) <= 25))
+                continue;
+            // Anything not r-dissolve with a magical adjustment is more resistant. Anything +-4 or better/worse is immune.
+            if( !object->flagIsSet(O_RESIST_DISOLVE) &&
+                (Random::get(1,100) <= (4 - abs(object->getAdjustment() )) ))
+            {
+                if(object->flagIsSet(O_NO_PREFIX)) {
+                    printColor("^y%s is dissolved by acid!\n", object->getCName());
+                } else {
+                    printColor("^yYour %s is dissolved by acid!\n", object->getCName());
+                }
+                logn("log.dissolve", "%s(L%d) lost %s to acid trap in room %s.\n",
+                        getCName(), level, object->getCName(), getRoomParent()->fullName().c_str());
+                delObj(object, true, false, true, false);
+                delete object;
             }
-            logn("log.dissolve", "%s(L%d) lost %s to acid in room %s.\n",
-                    getCName(), level, object->getCName(), getRoomParent()->fullName().c_str());
-            delObj(object, true, false, true, false);
-            delete object;
+            // Check if acid loses potency and stops dissolving inv items...20% chance + dexterity bonus
+            if (Random::get(1,100) <= (MAX(1,20+bonus(player->dexterity.getCur()))))
+                break;
         }
-        if (Random::get(1,100) <= 20)
-            break;
     }
+   
     checkDarkness();
 }

--- a/roguelike/traps.cpp
+++ b/roguelike/traps.cpp
@@ -1055,13 +1055,13 @@ void Player::loseAcid() {
     computeAttackPower();
 
     // 10% chance to attempt dissolving inventory possessions, reduced by higher dexterity bonus.
-    if ( Random:get(1,100) <= MAX(1,(10 - bonus(player->dexterity.getCur()))) )
+    if ( Random::get(1,100) <= MAX(1,(10 - bonus(dexterity.getCur()))) )
     {
         ObjectSet::iterator it;
         for( it = objects.begin() ; it != objects.end() ; ) {
             object = (*it++);
             // Bags have a much much rarer chance to attempt dissolve. (approx 25/10000 == .25%)
-            if(object->getType() == ObjectType::CONTAINER && (Random:get(1,10000) <= 25))
+            if(object->getType() == ObjectType::CONTAINER && (Random::get(1,10000) <= 25))
                 continue;
             // Anything not r-dissolve with a magical adjustment is more resistant. Anything +-4 or better/worse is immune.
             if( !object->flagIsSet(O_RESIST_DISOLVE) &&
@@ -1078,7 +1078,7 @@ void Player::loseAcid() {
                 delete object;
             }
             // Check if acid loses potency and stops dissolving inv items...20% chance + dexterity bonus
-            if (Random::get(1,100) <= (MAX(1,20+bonus(player->dexterity.getCur()))))
+            if (Random::get(1,100) <= (MAX(1,20+bonus(dexterity.getCur()))))
                 break;
         }
     }


### PR DESCRIPTION
Losing inv possessions from an acid trap is very bogus and pisses people off. Made it much rarer, especially for bags.

Could remove it altogether, but these traps are rare enough and in high enough level areas that I think it'll be ok to leave it in.