### PR TITLE
Update room.cpp

### DIFF
--- a/areas/room.cpp
+++ b/areas/room.cpp
@@ -539,11 +539,15 @@ void UniqueRoom::addPermObj() {
         for(j=0; j<n-m; j++) {
             if(!loadObject(crtm->cr, &object))
                 continue;
+
+            object->init();
+
             if(object->flagIsSet(O_RANDOM_ENCHANT))
                 object->randomEnchant();
 
             object->setFlag(O_PERM_ITEM);
             object->setDroppedBy(this, "PermObject");
+
             object->addToRoom(this);
         }
     }


### PR DESCRIPTION
Adding object->init() fixes it so perm objects that have random objects inside them will spawn one of the random objects, and not the actually random object item.