### PR TITLE
Remove clear long and clear short

### DIFF
--- a/areas/room.cpp
+++ b/areas/room.cpp
@@ -635,10 +635,10 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
             oStr << uRoom->info.str() << " - ";
         oStr << uRoom->getName() << "^x\n\n";
 
-        if(!player->flagIsSet(P_NO_SHORT_DESCRIPTION) && uRoom->getShortDescription() != "")
+        if(uRoom->getShortDescription() != "")
             oStr << uRoom->getShortDescription() << "\n";
 
-        if(!player->flagIsSet(P_NO_LONG_DESCRIPTION) && uRoom->getLongDescription() != "")
+        if(uRoom->getLongDescription() != "")
             oStr << uRoom->getLongDescription() << "\n";
 
     } else {

--- a/include/flags.hpp
+++ b/include/flags.hpp
@@ -134,8 +134,8 @@
 #define P_HIDDEN                    1        // Hidden
 #define P_HARDCORE                  2        // A hardcore character: death is permanent.
 #define P_NO_BROADCASTS             3        // Don't show broadcasts
-#define P_NO_LONG_DESCRIPTION       4        // Don't show long description
-#define P_NO_SHORT_DESCRIPTION      5        // Don't show short description
+// free                             4
+// free                             5
 #define P_IGNORE_GOSSIP             6        // ignore gossip channel
 #define P_IGNORE_CLAN               7        // ignore clan channel
 #define P_PORTAL                    8        // portal

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -20,7 +20,7 @@
 
 #define VERSION_MAJOR "2"
 #define VERSION_MINOR "5"
-#define VERSION_SUB "1a"
+#define VERSION_SUB "2"
 
 #define VERSION VERSION_MAJOR "." VERSION_MINOR VERSION_SUB
 

--- a/players/prefs.cpp
+++ b/players/prefs.cpp
@@ -112,8 +112,6 @@ prefInfo prefList[] =
 
     { "-Display",   0, nullptr, "", false },
     { "showall",    P_SHOW_ALL_PREFS,       nullptr,      "show all preferences",     false },
-    { "short",      P_NO_SHORT_DESCRIPTION, nullptr,      "short description",        true },
-    { "long",       P_NO_LONG_DESCRIPTION,  nullptr,      "long description",         true },
     { "nlprompt",   P_NEWLINE_AFTER_PROMPT, nullptr,      "newline after prompt",     false },
     { "xpprompt",   P_SHOW_XP_IN_PROMPT,    nullptr,      "show exp in prompt",       false },
     { "prompt",     P_PROMPT,               nullptr,      "descriptive prompt",       false },

--- a/xml/creatures-xml.cpp
+++ b/xml/creatures-xml.cpp
@@ -341,6 +341,16 @@ int Creature::readFromXml(xmlNodePtr rootNode, bool offline) {
                 addSkill("ring",initialSkill);
             }
         }
+
+         if(isPlayer()) {   
+
+            if(getVersion() < "2.52") {
+    #define P_NO_LONG_DESCRIPTION_OLD      4
+    #define P_NO_SHORT_DESCRIPTION_OLD     5
+                clearFlag(P_NO_LONG_DESCRIPTION_OLD);
+                clearFlag(P_NO_SHORT_DESCRIPTION_OLD);
+            }
+        }
     }
 
     setVersion();


### PR DESCRIPTION
Back during the dial-up days, clearing long and short descriptions improved throughput and reduced lag. This is no longer necessary or needed with modern day connections.

Staff unanimously agrees it is time for this option to go the way of the dodo bird.

Flags have been zeroed out and reclaimed.  Players will update when they log in. The version has been bumped to 2.5.2.