### PR TITLE
only stop pet attack when there is no target

### DIFF
--- a/combat/attack.cpp
+++ b/combat/attack.cpp
@@ -124,8 +124,7 @@ int cmdAttack(Creature* creature, cmd* cmnd) {
             pet->getMaster()->smashInvis();
 
             if(pet->isEnemy(victim)) {
-                pet->getMaster()->print("%M will stop attacking %N.\n", pet, victim);
-                pet->clearEnemy(victim);
+                pet->getMaster()->print("%M is already attacking %N.\n", pet, victim);
             } else {
                 creature->getMaster()->print("%M attacks %N.\n", pet, victim);
                 broadcast(creature->getMaster()->getSock(), pet->getRoomParent(), "%M tells %N to attack %N.",


### PR DESCRIPTION
Player may already command pet to stop attacking with by omitting a target: `pet k`, logic for this is above on line 105.
With this additional check, it's easy to get stuck accidentally stopping the attack when you're actually trying to start it, because of the pet assisting you on hit. So just removing that minor inconvenience.