### PR TITLE
remember exits when used

### DIFF
--- a/areas/room.cpp
+++ b/areas/room.cpp
@@ -718,7 +718,7 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
                 if(ext->flagIsSet(X_NEEDS_FLY))
                     oStr << "(fly)";
             } else {
-                // if player can see the exit and these flags are set, then the player has discovered and used this exit before.
+                // normal player can see the exit
                 if(ext->flagIsSet(X_SECRET) || ext->flagIsSet(X_DESCRIPTION_ONLY) || ext->isConcealed(player))
                     oStr << "(h)";
                 if(ext->isEffected("invisibility"))

--- a/areas/room.cpp
+++ b/areas/room.cpp
@@ -718,7 +718,7 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
                 if(ext->flagIsSet(X_NEEDS_FLY))
                     oStr << "(fly)";
             } else {
-                // normal player can see the exit
+                // if player can see the exit and these flags are set, then the player has discovered and used this exit before.
                 if(ext->flagIsSet(X_SECRET) || ext->flagIsSet(X_DESCRIPTION_ONLY) || ext->isConcealed(player))
                     oStr << "(h)";
                 if(ext->isEffected("invisibility"))

--- a/areas/room.cpp
+++ b/areas/room.cpp
@@ -609,7 +609,7 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
     int     n=0, m=0, flags = (player->displayFlags() | QUEST), staff=0;
     std::ostringstream oStr;
     std::string str = "";
-    bool    wallOfFire=false, wallOfThorns=false, canSee=false, hasBeenUsedBy=false;
+    bool    wallOfFire=false, wallOfThorns=false, canSee=false;
 
     const UniqueRoom* uRoom = room->getAsConstUniqueRoom();
     const AreaRoom* aRoom = room->getAsConstAreaRoom();
@@ -660,9 +660,8 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
     for(Exit* ext : room->exits) {
         wallOfFire = ext->isWall("wall-of-fire");
         wallOfThorns = ext->isWall("wall-of-thorns");
-        hasBeenUsedBy = ext->hasBeenUsedBy(player);
 
-        canSee = player->showExit(ext, magicShowHidden) || hasBeenUsedBy;
+        canSee = player->showExit(ext, magicShowHidden);
         if(canSee) {
             if(n)
                 oStr << "^g, ";
@@ -718,8 +717,14 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
                     oStr << "(desc)";
                 if(ext->flagIsSet(X_NEEDS_FLY))
                     oStr << "(fly)";
-            } else if(hasBeenUsedBy && ext->isDiscoverable()) {
-                oStr << "(h)";
+            } else {
+                // if player can see the exit and these flags are set, then the player has discovered and used this exit before.
+                if(ext->flagIsSet(X_SECRET) || ext->flagIsSet(X_DESCRIPTION_ONLY) || ext->isConcealed(player))
+                    oStr << "(h)";
+                if(ext->isEffected("invisibility"))
+                    oStr << "(*)";
+                if(ext->flagIsSet(X_NEEDS_FLY))
+                    oStr << "(fly)";
             }
 
             n++;

--- a/areas/room.cpp
+++ b/areas/room.cpp
@@ -609,7 +609,7 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
     int     n=0, m=0, flags = (player->displayFlags() | QUEST), staff=0;
     std::ostringstream oStr;
     std::string str = "";
-    bool    wallOfFire=false, wallOfThorns=false, canSee=false;
+    bool    wallOfFire=false, wallOfThorns=false, canSee=false, hasBeenUsedBy=false;
 
     const UniqueRoom* uRoom = room->getAsConstUniqueRoom();
     const AreaRoom* aRoom = room->getAsConstAreaRoom();
@@ -660,8 +660,9 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
     for(Exit* ext : room->exits) {
         wallOfFire = ext->isWall("wall-of-fire");
         wallOfThorns = ext->isWall("wall-of-thorns");
+        hasBeenUsedBy = ext->hasBeenUsedBy(player);
 
-        canSee = player->showExit(ext, magicShowHidden);
+        canSee = player->showExit(ext, magicShowHidden) || hasBeenUsedBy;
         if(canSee) {
             if(n)
                 oStr << "^g, ";
@@ -717,6 +718,8 @@ void displayRoom(Player* player, const BaseRoom* room, int magicShowHidden) {
                     oStr << "(desc)";
                 if(ext->flagIsSet(X_NEEDS_FLY))
                     oStr << "(fly)";
+            } else if(hasBeenUsedBy && ext->isDiscoverable()) {
+                oStr << "(h)";
             }
 
             n++;

--- a/include/mudObjects/exits.hpp
+++ b/include/mudObjects/exits.hpp
@@ -89,7 +89,7 @@ public:
 
     bool isDiscoverable() const;
     bool hasBeenUsedBy(std::string id) const;
-    bool hasBeenUsedBy(Player* player) const;
+    bool hasBeenUsedBy(const Player* player) const;
 
 //// Effects
     bool pulseEffects(time_t t);

--- a/include/mudObjects/exits.hpp
+++ b/include/mudObjects/exits.hpp
@@ -87,6 +87,10 @@ public:
     [[nodiscard]] bool isWall(std::string_view name) const;
     bool isConcealed(const Creature* viewer=nullptr) const;
 
+    bool isDiscoverable() const;
+    bool hasBeenUsedBy(std::string id) const;
+    bool hasBeenUsedBy(Player* player) const;
+
 //// Effects
     bool pulseEffects(time_t t);
     bool doEffectDamage(Creature* target);
@@ -120,6 +124,8 @@ public:
     char        clanFlags[4]{};   // clan allowed flags
     char        classFlags[4]{};  // class allowed flags
     char        raceFlags[4]{};   // race allowed flags
+
+    std::list<std::string> usedBy; // ids of players that have used this exit
 
     Location target;
 

--- a/include/mudObjects/exits.hpp
+++ b/include/mudObjects/exits.hpp
@@ -125,7 +125,7 @@ public:
     char        classFlags[4]{};  // class allowed flags
     char        raceFlags[4]{};   // race allowed flags
 
-    std::list<std::string> usedBy; // ids of players that have used this exit
+    std::set<std::string> usedBy; // ids of players that have used this exit
 
     Location target;
 

--- a/movement/exits.cpp
+++ b/movement/exits.cpp
@@ -62,6 +62,7 @@ Exit::Exit() {
     hooks.setParent(this);
     parentRoom = nullptr;
     direction = NoDirection;
+    usedBy = {};
 }
 
 Exit::~Exit() {
@@ -500,6 +501,25 @@ bool Exit::isConcealed(const Creature* viewer) const {
     if(isEffected("concealed") && (!viewer || !viewer->willIgnoreIllusion()))
         return(true);
     return(false);
+}
+
+//*********************************************************************
+//                      isDiscoverable
+//*********************************************************************
+
+bool Exit::isDiscoverable() const {
+    return(flagIsSet(X_SECRET) || flagIsSet(X_DESCRIPTION_ONLY) || flagIsSet(X_CONCEALED));
+}
+
+//**********************************************************************
+//                      hasBeenUsedBy
+//**********************************************************************
+
+bool Exit::hasBeenUsedBy(std::string id) const {
+    return std::find(usedBy.begin(), usedBy.end(), id) != usedBy.end();
+}
+bool Exit::hasBeenUsedBy(Player* player) const {
+    return(hasBeenUsedBy(player->getId()));
 }
 
 //*********************************************************************

--- a/movement/exits.cpp
+++ b/movement/exits.cpp
@@ -514,7 +514,9 @@ bool Exit::isDiscoverable() const {
     return(
         flagIsSet(X_SECRET) ||
         flagIsSet(X_DESCRIPTION_ONLY) ||
-        flagIsSet(X_CONCEALED)
+        flagIsSet(X_CONCEALED) ||
+        flagIsSet(X_NEEDS_FLY) ||
+        isEffected("invisibility")
     );
 }
 

--- a/movement/exits.cpp
+++ b/movement/exits.cpp
@@ -514,9 +514,7 @@ bool Exit::isDiscoverable() const {
     return(
         flagIsSet(X_SECRET) ||
         flagIsSet(X_DESCRIPTION_ONLY) ||
-        flagIsSet(X_CONCEALED) ||
-        flagIsSet(X_NEEDS_FLY) ||
-        isEffected("invisibility")
+        flagIsSet(X_CONCEALED)
     );
 }
 

--- a/movement/exits.cpp
+++ b/movement/exits.cpp
@@ -437,6 +437,9 @@ std::string Exit::blockedByStr(char color, std::string_view spell, std::string_v
 bool Player::showExit(const Exit* exit, int magicShowHidden) const {
     if(isStaff())
         return(true);
+    if(exit->isDiscoverable() && exit->hasBeenUsedBy(this)){
+        return(true);
+    }
     return( canSee(exit) &&
         (!exit->flagIsSet(X_SECRET) || magicShowHidden) &&
         (!exit->isConcealed(this) || magicShowHidden) &&
@@ -508,7 +511,13 @@ bool Exit::isConcealed(const Creature* viewer) const {
 //*********************************************************************
 
 bool Exit::isDiscoverable() const {
-    return(flagIsSet(X_SECRET) || flagIsSet(X_DESCRIPTION_ONLY) || flagIsSet(X_CONCEALED));
+    return(
+        flagIsSet(X_SECRET) ||
+        flagIsSet(X_DESCRIPTION_ONLY) ||
+        flagIsSet(X_CONCEALED) ||
+        flagIsSet(X_NEEDS_FLY) ||
+        isEffected("invisibility")
+    );
 }
 
 //**********************************************************************
@@ -518,7 +527,7 @@ bool Exit::isDiscoverable() const {
 bool Exit::hasBeenUsedBy(std::string id) const {
     return std::find(usedBy.begin(), usedBy.end(), id) != usedBy.end();
 }
-bool Exit::hasBeenUsedBy(Player* player) const {
+bool Exit::hasBeenUsedBy(const Player* player) const {
     return(hasBeenUsedBy(player->getId()));
 }
 

--- a/movement/movement.cpp
+++ b/movement/movement.cpp
@@ -1027,6 +1027,7 @@ BaseRoom* Move::start(Creature* creature, cmd* cmnd, Exit **gExit, bool leader, 
         mem = newRoom->getAsAreaRoom()->getStayInMemory();
         newRoom->getAsAreaRoom()->setStayInMemory(true);
     }
+
     // we have to run a manual isFull check here because nobody is
     // in the room yet
     (*numPeople)++;
@@ -1176,6 +1177,12 @@ int cmdGo(Player* player, cmd* cmnd) {
         Move::track(oldRoom, oldMarker, exit, player, &followers);
 
     delete oldMarker;
+
+    // remember this exit if it is hidden/concealed
+    if(exit->isDiscoverable() && !exit->hasBeenUsedBy(player)) {
+        exit->usedBy.push_back(player->getId());
+        oldRoom->saveToFile(1);
+    }
 
     // for display reasons, we only need to kill objects in
     // the room they're entering

--- a/movement/movement.cpp
+++ b/movement/movement.cpp
@@ -1180,7 +1180,7 @@ int cmdGo(Player* player, cmd* cmnd) {
 
     // remember this exit if it is hidden/concealed
     if(exit->isDiscoverable() && !exit->hasBeenUsedBy(player)) {
-        exit->usedBy.push_back(player->getId());
+        exit->usedBy.insert(player->getId());
         oldRoom->saveToFile(1);
     }
 

--- a/xml/exits-xml.cpp
+++ b/xml/exits-xml.cpp
@@ -168,11 +168,10 @@ int Exit::saveToXml(xmlNodePtr parentNode) const {
     xml::saveNonNullString(rootNode, "Enter", enter);
     xml::saveNonNullString(rootNode, "Open", open);
 
-    std::list<std::string>::const_iterator ub;
     if(!usedBy.empty()) {
         childNode = xml::newStringChild(rootNode, "UsedBy");
         for(auto const& ply: usedBy) {
-            xml::newStringChild(childNode, "Player", (*ub));
+            xml::newStringChild(childNode, "Player", (*ply));
         }
     }
 

--- a/xml/exits-xml.cpp
+++ b/xml/exits-xml.cpp
@@ -171,7 +171,7 @@ int Exit::saveToXml(xmlNodePtr parentNode) const {
     std::list<std::string>::const_iterator ub;
     if(!usedBy.empty()) {
         childNode = xml::newStringChild(rootNode, "UsedBy");
-        for(ub = usedBy.begin() ; ub != usedBy.end() ; ub++) {
+        for(auto const& ply: usedBy) {
             xml::newStringChild(childNode, "Player", (*ub));
         }
     }

--- a/xml/exits-xml.cpp
+++ b/xml/exits-xml.cpp
@@ -81,7 +81,7 @@ int Exit::readFromXml(xmlNodePtr rootNode, BaseRoom* room, bool offline) {
                 if(NODE_NAME(childNode, "Player")) {
                     std::string s;
                     xml::copyToString(s, childNode);
-                    usedBy.push_back(s);
+                    usedBy.insert(s);
                 }
                 childNode = childNode->next;
             }
@@ -170,8 +170,8 @@ int Exit::saveToXml(xmlNodePtr parentNode) const {
 
     if(!usedBy.empty()) {
         childNode = xml::newStringChild(rootNode, "UsedBy");
-        for(auto const& ply: usedBy) {
-            xml::newStringChild(childNode, "Player", (*ply));
+        for(auto const &ply: usedBy) {
+            xml::newStringChild(childNode, "Player", ply);
         }
     }
 


### PR DESCRIPTION
Exits store a list of player ids that have used it if they are hidden, concealed, or desc-only.
If a player is in that list when displaying the room, show the exit and add the (h).