### PR TITLE
Update *award command

### DIFF
--- a/commands/cmd.cpp
+++ b/commands/cmd.cpp
@@ -322,7 +322,6 @@ bool Config::initCommands() {
     staffCommands.emplace("*group", 100, dmGroup, isCt, "See who is grouped with a player.");
     staffCommands.emplace("*dust", 100, dmDust, isCt, "Permanently delete a player.");
     staffCommands.emplace("*tell", 100, dmFlash, isDm, "Send a player a message.");
-    staffCommands.emplace("*award", 100, dmAward, isCt, "Award a player roleplaying exp/gold.");
     staffCommands.emplace("*beep", 100, dmBeep, isDm, "Make the player's terminal beep.");
     staffCommands.emplace("*advance", 100, dmAdvance, isDm, "Change the player's level and adjust stats appropriately.");
     staffCommands.emplace("dmfinger", 100, dmFinger, isDm, "fup an offline player's information.");
@@ -456,6 +455,7 @@ bool Config::initCommands() {
     playerCommands.emplace("*typo", 100, reportTypo, nullptr, "");
     playerCommands.emplace("*gag", 100, dmGag, nullptr, "");
     playerCommands.emplace("*wts", 100, channel, nullptr, "");
+    playerCommands.emplace("*award", 100, dmAward, nullptr, "Award a player roleplaying exp/gold.");
 
     playerCommands.emplace("compare", 90, cmdCompare, nullptr, "Compare two items.");
     playerCommands.emplace("weapons", 100, cmdWeapons, nullptr, "Use weapon trains.");

--- a/staff/dmply.cpp
+++ b/staff/dmply.cpp
@@ -531,7 +531,7 @@ int dmAward(Player* player, cmd* cmnd) {
     long    i=0, t=0, amount=0, gp=0;
     char    temp[80];
 
-    if(!player->flagIsSet(P_CAN_AWARD) && !player->isDm() && !player->flagIsSet(P_WATCHER))
+    if(!player->flagIsSet(P_CAN_AWARD) && !player->isDm() && !player->isWatcher())
         return(cmdNoAuth(player));
 
     if(cmnd->num < 2) {
@@ -603,14 +603,14 @@ int dmAward(Player* player, cmd* cmnd) {
 
 
     target->lasttime[LT_RP_AWARDED].ltime = t;
-    if(player->getClass() == CreatureClass::CARETAKER)
+    if(player->isCt())
         target->lasttime[LT_RP_AWARDED].interval = 300L; // 5 minutes.
     else // We have a watcher
         target->lasttime[LT_RP_AWARDED].interval = 900L; // 15 minutes.
 
     
 
-    if(!strcmp(cmnd->str[2], "-g") && !player->flagIsSet(P_WATCHER)) { // Watchers cannot award gold
+    if(!strcmp(cmnd->str[2], "-g") && !player->isWatcher()) { // Watchers cannot award gold
         gp = MAX(500L, MIN(cmnd->val[2],1000000L));            
         player->print("%ld gold awarded to %s for good roleplaying and/or being greatly helpful.\n", gp, target->getCName());
         target->printColor("^GYou have been awarded ^Y%ld gold^G as well! It was put in your bank account.\n", gp);


### PR DESCRIPTION
Fixed it so watchers can now *award.
Watchers can only *award the default XP grant of 1% of current XP, or 500XP, whichever is higher.

Changed it so CTs can now also grant X gold with -g switch. They couldn't before. CTs have 5 minutes between *awards of a player, while watchers must wait 15 minutes.