### PR TITLE
xflag to prevent remembering exit

### DIFF
--- a/include/flags.hpp
+++ b/include/flags.hpp
@@ -765,7 +765,7 @@
 
 // Exit flags
 #define X_SECRET                    0         // Secret
-// Free                             1
+#define X_NO_REMEMBER               1         // Unable to remember this exit
 #define X_LOCKED                    2         // Locked
 #define X_CLOSED                    3         // Closed
 #define X_LOCKABLE                  4         // Lockable

--- a/movement/exits.cpp
+++ b/movement/exits.cpp
@@ -514,11 +514,14 @@ bool Exit::isConcealed(const Creature* viewer) const {
 
 bool Exit::isDiscoverable() const {
     return(
-        flagIsSet(X_SECRET) ||
-        flagIsSet(X_DESCRIPTION_ONLY) ||
-        flagIsSet(X_CONCEALED) ||
-        flagIsSet(X_NEEDS_FLY) ||
-        isEffected("invisibility")
+        !flagIsSet(X_NO_REMEMBER) &&
+        (
+            flagIsSet(X_SECRET) ||
+            flagIsSet(X_DESCRIPTION_ONLY) ||
+            flagIsSet(X_CONCEALED) ||
+            flagIsSet(X_NEEDS_FLY) ||
+            isEffected("invisibility")
+        )
     );
 }
 


### PR DESCRIPTION
This is just the flag itself and the logic for it -- it looks like exits.xml would need to be updated too, but I don't have access to the real data. Until the xml gets updated, it will look like the invis flag instead, e.g. `no_remember: 1724 Flags: Hidden(1), Invisible(2).` but it works.