### PR TITLE
mage/lich QoL - ports and anchors

### DIFF
--- a/include/global.hpp
+++ b/include/global.hpp
@@ -21,7 +21,7 @@
 
 #include "enums/bits.hpp"
 
-#define MAX_DIMEN_ANCHORS   3
+#define MAX_DIMEN_ANCHORS   5
 
 // Size of exp array, also highest you can train
 const int MAXALVL = 40;

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -20,7 +20,7 @@
 
 #define VERSION_MAJOR "2"
 #define VERSION_MINOR "5"
-#define VERSION_SUB "4e"
+#define VERSION_SUB "4f"
 
 #define VERSION VERSION_MAJOR "." VERSION_MINOR VERSION_SUB
 

--- a/magic/schools/translocation.cpp
+++ b/magic/schools/translocation.cpp
@@ -609,7 +609,8 @@ int splTeleport(Creature* player, cmd* cmnd, SpellData* spellData) {
 
     strcpy(dest, "");
 
-    if(spellData->how == CastType::CAST && !player->checkMp(50))
+
+    if(spellData->how == CastType::CAST && !player->checkMp(30))
         return(0);
 
     if(spellData->how == CastType::CAST) {
@@ -634,8 +635,6 @@ int splTeleport(Creature* player, cmd* cmnd, SpellData* spellData) {
         ) {
             player->print("The spell fizzles.\n");
             player->print("You cannot cast that spell in this room.\n");
-            if(spellData->how == CastType::CAST)
-                player->subMp(50);
             return(0);
         }
     }
@@ -848,7 +847,7 @@ int splTeleport(Creature* player, cmd* cmnd, SpellData* spellData) {
                 if(target->getSock())
                     target->print("%M tried to teleport you.\n", player);
                 if(spellData->how == CastType::CAST)
-                    player->subMp(50);
+                    player->subMp(30);
                 return(1);
             }
         }
@@ -866,7 +865,7 @@ int splTeleport(Creature* player, cmd* cmnd, SpellData* spellData) {
 
             newRoom = player->teleportWhere();
             if(spellData->how == CastType::CAST)
-                player->subMp(50);
+                player->subMp(30);
 
             if(pTarget) {
                 pTarget->deleteFromRoom();

--- a/players/player.cpp
+++ b/players/player.cpp
@@ -148,12 +148,17 @@ void Player::init() {
         daily[DL_ENCHA].max = 3;
         daily[DL_FHEAL].max = MAX(3, 3 + (level) / 3);
         daily[DL_TRACK].max = MAX(3, 3 + (level) / 3);
-        daily[DL_DEFEC].max = 1;
-        //  daily[DL_TELEP].max = MAX(3, MAX(2, level/4));
-        daily[DL_TELEP].max = 3;
-        if(level < 13)
+        daily[DL_DEFEC].max = 1;    
+        
+         if(level < 15)
             daily[DL_TELEP].max = 1;
-        //  daily[DL_ETRVL].max = MAX(3, MAX(2, level/4));
+        else
+            daily[DL_TELEP].max = 3;
+
+        // Mages and liches get more ports than other classes; dependent on translocation magic skill
+        if (getClass() == CreatureClass::MAGE || getClass() == CreatureClass::LICH)
+            daily[DL_TELEP].max = MIN(10, (int)getSkillLevel("translocation")/5);
+
         daily[DL_RCHRG].max = MAX(7, level / 2);
         daily[DL_HANDS].max = 3;
 

--- a/xml/creatures-xml.cpp
+++ b/xml/creatures-xml.cpp
@@ -373,7 +373,15 @@ int Creature::readFromXml(xmlNodePtr rootNode, bool offline) {
                     saves[a].chance = MIN<short>(99,saves[a].chance);
              }
 
+              if(getVersion() < "2.54f") {
+                if (level < 15)
+                    daily[DL_TELEP].cur = 1;
+                else
+                    daily[DL_TELEP].cur = 3;
+                if (getClass() == CreatureClass::MAGE || getClass() == CreatureClass::LICH)
+                    daily[DL_TELEP].cur = MIN(10, (int)getSkillLevel("translocation")/5);
 
+             }
         }
     }
 


### PR DESCRIPTION
Change requested by Charmane asking for more ports.

For mage/lich, ports per day changed to translocation skill level/5, max 10 (10 will be max even after we someday raise the level limit past 40). For now while they can still cast it, other classes always get basic 1 daily port before level 15, and basic 3 after.
Max dimensional anchors allowed increased from 3 to 5.

Also fixed MP costs in teleport spell code. It was all screwed up sometimes costing 50 when is supposed to be:
-30 for teleport self or other
-60 if using an anchor.
Don't know where the 50 was coming from but it's gone now.