### PR TITLE
Fix wall spells

### DIFF
--- a/areas/room.cpp
+++ b/areas/room.cpp
@@ -604,7 +604,7 @@ void displayRoom(const std::shared_ptr<Player>& player, const std::shared_ptr<Ba
     int flags = (player->displayFlags() | QUEST);
     std::ostringstream oStr;
     std::string str;
-    bool    wallOfFire=false, wallOfThorns=false, canSee=false;
+    bool    wallOfFire=false, wallOfThorns=false, wallOfLightning=false, wallOfSleet=false, canSee=false;
 
     const std::shared_ptr<const UniqueRoom> uRoom = room->getAsConstUniqueRoom();
     const std::shared_ptr<const AreaRoom> aRoom = room->getAsConstAreaRoom();
@@ -655,6 +655,8 @@ void displayRoom(const std::shared_ptr<Player>& player, const std::shared_ptr<Ba
     for(const auto& ext : room->exits) {
         wallOfFire = ext->isWall("wall-of-fire");
         wallOfThorns = ext->isWall("wall-of-thorns");
+        wallOfLightning = ext->isWall("wall-of-lightning");
+        wallOfSleet = ext->isWall("wall-of-sleet");
 
         canSee = player->showExit(ext, magicShowHidden);
         if(canSee) {
@@ -669,7 +671,11 @@ void displayRoom(const std::shared_ptr<Player>& player, const std::shared_ptr<Ba
             if(wallOfFire) {
                 oStr << "R";
             } else if(wallOfThorns) {
-                oStr << "o";
+                oStr << "y";
+            } else if(wallOfLightning) {
+                oStr << "c";
+            } else if(wallOfSleet) {
+                oStr << "C";
             } else if(  !player->flagIsSet(P_NO_EXTRA_COLOR) &&
                 (   !player->canEnter(ext) || (
                         ext->target.room.id && (
@@ -726,11 +732,15 @@ void displayRoom(const std::shared_ptr<Player>& player, const std::shared_ptr<Ba
         }
 
         if(wallOfFire)
-            str += ext->blockedByStr('R', "wall of fire", "wall-of-fire", flags & MAG, canSee);
+            str += ext->blockedByStr('R', "wall-of-fire", "wall-of-fire", flags & MAG, canSee);
         if(ext->isWall("wall-of-force"))
-            str += ext->blockedByStr('s', "wall of force", "wall-of-force", flags & MAG, canSee);
+            str += ext->blockedByStr('M', "wall-of-force", "wall-of-force", flags & MAG, canSee);
         if(wallOfThorns)
-            str += ext->blockedByStr('o', "wall of thorns", "wall-of-thorns", flags & MAG, canSee);
+            str += ext->blockedByStr('y', "wall-of-thorns", "wall-of-thorns", flags & MAG, canSee);
+        if(wallOfLightning)
+            str += ext->blockedByStr('c', "wall-of-lightning", "wall-of-lightning", flags & MAG, canSee);
+        if(wallOfSleet)
+            str += ext->blockedByStr('C', "wall-of-sleet", "wall-of-sleet", flags & MAG, canSee);
 
     }
 

--- a/combat/die.cpp
+++ b/combat/die.cpp
@@ -2075,6 +2075,16 @@ void Player::die(DeathType dt) {
         logn("log.death", "%s was disintegrated by sunlight.\n", getCName());
         death = "sunlight";
         break;
+    case ELECTROCUTED:
+        sprintf(deathStr, "### Sadly, %s was electrocuted to death by a wall-of-lightning.", getCName());
+        logn("log.death", "%s was electrocuted to death by by a wall-of-lightning.\n", getCName());
+        death = "a wall of lightning";
+        break;
+    case FROZEN_CUT:
+        sprintf(deathStr, "### Sadly, %s was frozen and sliced to pieces by a wall-of-sleet.", getCName());
+        logn("log.death", "%s was frozen and sliced to pieces by a wall-of-sleet.\n", getCName());
+        death = "a wall of sleet";
+        break;
     default:
         sprintf(deathStr, "### Sadly, %s died.", getCName());
         logn("log.death", "%s was killed by %s.\n", getCName(), getCName());

--- a/commands/command2.cpp
+++ b/commands/command2.cpp
@@ -966,32 +966,37 @@ int cmdKnock(const std::shared_ptr<Creature>& creature, cmd* cmnd) {
     std::shared_ptr<Exit> exit=nullptr;
 
     if(cmnd->num < 2) {
-        creature->print("Knock on what exit?\n");
+        *creature << "Knock on what exit?\n";
         return(0);
     }
 
     lowercize(cmnd->str[1], 0);
     exit = findExit(creature, cmnd);
     if(!exit) {
-        creature->print("Knock on what exit?\n");
+        *creature << "You don't see that exit here.\n";
         return(0);
     }
 
     if(!exit->flagIsSet(X_CLOSED)) {
-        creature->print("That exit is not closed!\n");
+        *creature << "You can't knock on that. It's not closed!\n";
         return(0);
     }
 
     creature->getParent()->wake("You awaken suddenly!", true);
-    creature->printColor("You knock on the %s^x.\n", exit->getCName());
-    broadcast(creature->getSock(), creature->getRoomParent(), "%M knocks on the %s^x.", creature.get(), exit->getCName());
+    
+    *creature << "You knock on the '" << exit->getCName() << "' exit.\n";
+    broadcast(creature->getSock(), creature->getRoomParent(), "%M knocks on the '%s' exit.", creature.get(), exit->getCName());
 
+    targetRoom = exit->target.loadRoom();
+    if (!targetRoom) 
+        return(0);
+    
     // change the meaning of exit
     exit = exit->getReturnExit(creature->getRoomParent(), targetRoom);
     targetRoom->wake("You awaken suddenly!", true);
 
     if(exit)
-        broadcast((std::shared_ptr<Socket> )nullptr, targetRoom, "You hear someone knocking on the %s.", exit.get());
+        broadcast((std::shared_ptr<Socket> )nullptr, targetRoom, "You hear someone knocking on the %s exit.", exit->getCName());
     else
         broadcast((std::shared_ptr<Socket> )nullptr, targetRoom, "You hear the sound of someone knocking.");
     return(0);

--- a/commands/command2.cpp
+++ b/commands/command2.cpp
@@ -99,11 +99,15 @@ void lookAtExit(const std::shared_ptr<Player>& player, const std::shared_ptr<Exi
     if(exit->flagIsSet(X_LOCKED))
         player->print("It is locked.\n");
     if(exit->isWall("wall-of-fire"))
-        player->print("It is blocked by a wall of fire.\n");
+        player->print("It is blocked by a wall-of-fire.\n");
     if(exit->isWall("wall-of-force"))
-        player->print("It is blocked by a wall of force.\n");
+        player->print("It is blocked by a wall-of-force.\n");
     if(exit->isWall("wall-of-thorns"))
-        player->print("It is blocked by a wall of thorns.\n");
+        player->print("It is blocked by a wall-of-thorns.\n");
+    if(exit->isWall("wall-of-lightning"))
+        player->print("It is blocked by a wall-of-lightning.\n");
+    if(exit->isWall("wall-of-sleet"))
+        player->print("It is blocked by a wall-of-sleet.\n");
 
     const std::shared_ptr<Monster>  guard = player->getRoomParent()->getGuardingExit(exit, player);
     if(guard && !player->checkStaff("%M %s.\n", guard.get(), guard->flagIsSet(M_FACTION_NO_GUARD) ? "doesn't like you enough to let you look there" : "won't let you look there"))

--- a/commands/communication.cpp
+++ b/commands/communication.cpp
@@ -1181,7 +1181,6 @@ int cmdSpeak(const std::shared_ptr<Player>& player, cmd* cmnd) {
             switch (cmnd->str[1][2]) {
             case 'l':
                 lang = LCELESTIAL;
-                *player << "lang = " << lang << "\n";
                 break;
             case 'n':
                 lang = LCENTAUR;

--- a/commands/communication.cpp
+++ b/commands/communication.cpp
@@ -1181,6 +1181,7 @@ int cmdSpeak(const std::shared_ptr<Player>& player, cmd* cmnd) {
             switch (cmnd->str[1][2]) {
             case 'l':
                 lang = LCELESTIAL;
+                *player << "lang = " << lang << "\n";
                 break;
             case 'n':
                 lang = LCENTAUR;
@@ -1190,6 +1191,7 @@ int cmdSpeak(const std::shared_ptr<Player>& player, cmd* cmnd) {
                 return(0);
                 break;        
             }
+        break;
         case 'o':
             lang = LCOMMON;
             break;
@@ -1229,6 +1231,7 @@ int cmdSpeak(const std::shared_ptr<Player>& player, cmd* cmnd) {
             break;
         case 'i':
             lang = LFIRBOLG;
+            break;
         default:
             player->print("You do not know that language.\n");
             return(0);
@@ -1255,11 +1258,13 @@ int cmdSpeak(const std::shared_ptr<Player>& player, cmd* cmnd) {
                     return(0);
                     break;
                 }
+            break;
             default:
                 player->print("You do not know that language.\n");
                 return(0);
                 break;
             }
+        break;
         case 'o':
             lang = LGOBLINOID;
             break;
@@ -1300,6 +1305,7 @@ int cmdSpeak(const std::shared_ptr<Player>& player, cmd* cmnd) {
                 return(0);
                 break;
             }
+            break;
         }
         break;
     case 'i':
@@ -1384,7 +1390,6 @@ int cmdSpeak(const std::shared_ptr<Player>& player, cmd* cmnd) {
         return(0);
         break;
     }
-
 
     if(lang == player->current_language) {
         player->print("You're already speaking %s!\n", get_language_adj(lang));

--- a/creatures/creature.cpp
+++ b/creatures/creature.cpp
@@ -423,7 +423,9 @@ bool mobileEnter(const std::shared_ptr<Exit>& exit) {
         !exit->flagIsSet(X_DESCRIPTION_ONLY) &&
         !exit->isWall("wall-of-fire") &&
         !exit->isWall("wall-of-force") &&
-        !exit->isWall("wall-of-thorns")
+        !exit->isWall("wall-of-thorns") &&
+        !exit->isWall("wall-of-lightning") &&
+        !exit->isWall("wall-of-sleet")
     );
 }
 

--- a/creatures/creatureAttr.cpp
+++ b/creatures/creatureAttr.cpp
@@ -1449,6 +1449,101 @@ bool Creature::isUndead() const {
     return(false);
 }
 
+//********************************************************************
+//                      isPureArcaneCaster
+//********************************************************************
+bool Creature::isPureArcaneCaster() const {
+    switch (getClass()) {
+    case CreatureClass::MAGE:
+    case CreatureClass::LICH:
+        return(true);
+        break;
+    default:
+        return(false);
+    }
+
+    if (isMonster()) {
+        switch (getType()) {
+        case DRAGON:
+        case DEMON:
+        case DEVIL:
+        case DEVA:
+            return(true);
+            break;
+        default:
+            return(false);
+            break;
+        }
+    }
+    return(false);
+}
+//********************************************************************
+//                      isHybridArcaneCaster
+//********************************************************************
+bool Creature::isHybridArcaneCaster() const {
+    if (isPlayer()) {
+        if (getAsConstPlayer()->getSecondClass() == CreatureClass::MAGE)
+            return(true);
+    }
+    switch (getClass()) {
+    case CreatureClass::BARD:
+    case CreatureClass::PUREBLOOD:
+        return(true);
+        break;
+    default:
+        return(false);
+    }
+    return(false);
+}
+//********************************************************************
+//                      isPureDivineCaster
+//********************************************************************
+bool Creature::isPureDivineCaster() const {
+    switch (getClass()) {
+    case CreatureClass::CLERIC:
+    case CreatureClass::DRUID:
+        return(true);
+        break;
+    default:
+        return(false);
+    }
+
+    if (isMonster()) {
+        switch (getType()) {
+        case DEMON:
+        case DEVIL:
+        case DEVA:
+        case FAERIE:
+        case ELEMENTAL:
+            return(true);
+            break;
+        default:
+            return(false);
+            break;
+        }
+    }
+    return(false);
+}
+
+//********************************************************************
+//                      isHybridDivineCaster
+//********************************************************************
+bool Creature::isHybridDivineCaster() const {
+    if (isPlayer()) {
+        if (getAsConstPlayer()->getSecondClass() == CreatureClass::CLERIC)
+        return(true);
+    }
+    switch (getClass()) {
+    case CreatureClass::PALADIN:
+    case CreatureClass::DEATHKNIGHT:
+    case CreatureClass::RANGER:
+        return(true);
+        break;
+    default:
+        return(false);
+    }
+    return(false);
+}
 //*********************************************************************
 //                      isUnconscious
 //*********************************************************************

--- a/creatures/creatures.cpp
+++ b/creatures/creatures.cpp
@@ -1435,8 +1435,8 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
             return(true);
         break;
     case CreatureClass::RANGER:
-        //Rangers hate undead as much as druids do
-        if (enemy->isUndead())
+        //Rangers hate undead as much as druids do, but they have a little moral wiggle room for recently turned undead
+        if (enemy->isUndead() && enemy->getAdjustedAlignment()<BLUISH)
             return(true);
         //TODO: If we ever add in ranger hated enemies...put check here
         break;

--- a/creatures/creatures.cpp
+++ b/creatures/creatures.cpp
@@ -1248,6 +1248,7 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
     short eAlign = enemy->getAlignment();
     int eMtype = enemy->getType();
 
+   
     //check hatreds using caller's race first
     switch(getRace()) {
     case DWARF:
@@ -1257,6 +1258,7 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
             return(true);
         if (eMtype == GIANTKIN || eMtype == GOBLINOID)
             return(true);
+        break;
     case ELF:
     case GREYELF:
     case WILDELF:
@@ -1265,6 +1267,7 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
         //Elves hate evil fey
         if (eMtype == FAERIE && eAlign < 0)
             return(true);
+        break;
     case ORC:
         if(eRace==DWARF || eRace==ELF || eRace==BUGBEAR || 
            eRace==HALFELF || eRace==GNOME || eRace==HALFLING)
@@ -1272,15 +1275,18 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
         //Orcs hate good fey
         if (eMtype == FAERIE && eAlign > 0)
             return(true);
+        break;
     case GNOME:
         if(eRace==GOBLIN || eRace==ORC || eRace==KOBOLD)
             return(true);
     case TROLL:
         if(eRace==DWARF || eRace==MINOTAUR || eRace==KATARAN)
             return(true);
+        break;
     case OGRE:
         if(eRace==DWARF || eRace==ELF)
             return(true);
+        break;
     case DARKELF:
         //Darkelves in general consider themselves superior to all other races, but they truely despise elves
         if(eRace==ELF || eRace==WILDELF || eRace==GREYELF)
@@ -1288,6 +1294,7 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
         //Darkelves hate good fey
         if (eMtype == FAERIE && eAlign > 0)
             return(true);
+        break;
     case GOBLIN: 
         //A lot of the evil humanoid races tend to torture goblins and/or enslave them...
         //Plus, they're generally just hateful little bastards
@@ -1297,36 +1304,46 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
         //Goblins hate good fey
         if (eMtype == FAERIE && eAlign > 0)
             return(true);
+        break;
     case HALFLING:
         if (eRace==ORC || eRace==GOBLIN || eRace==KOBOLD)
             return(true);
+        break;
     case MINOTAUR:
         //Minotaurs hate trolls because they have ancient grudges about prefering similar territory
         if(eRace==TROLL)
             return(true);
+        break;
     case KOBOLD:
         if(eRace==OGRE || eRace==GNOME || eRace==HALFLING)
             return(true);
+        break;
     case KATARAN:
         if(eRace==TROLL)
             return(true);
+        break;
     case CAMBION:
         if(eRace==SERAPH)
             return(true);
+        break;
     case DUERGAR:
         if(eRace==DWARF)
             return(true);
+        break;
     //Gnolls and barbarians hate one another because they often violently compete for the same terrtories
     case GNOLL:
         if(eRace==BARBARIAN)
             return(true);
+        break;
     case BARBARIAN:
         if(eRace==GNOLL)
             return(true);
+        break;
     case KENKU:
         //Kenku are bird people and hate katarans because they are cat people and often eat them
         if(eRace==KATARAN)
             return(true);
+        break;
     default:
         break; 
     }//End race check
@@ -1336,15 +1353,17 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
     switch(getDeity()) {
     case ARAMON: 
         //Aramon hates all good gods
-        if (enemy->getDeityAlignment() > NEUTRAL)
+        if (enemy->getDeityAlignment() > NEUTRAL) 
             return(true);
         //Aramon hates devas (angels) and considers seraphs to be unclean
-        if (eMtype == DEVA || eRace==SERAPH)
+        if (eMtype == DEVA || eRace==SERAPH) 
             return(true);
+        break;
     case CERIS: 
         //Ceris ia a hippie...She doesn't hate on anything - except for undead!
         if(enemy->isUndead())
             return(true);
+        break;
     case ENOCH: 
         //Enoch hates Aramon and Arachnus, wants to erradicate Ceris, and considers all cambions and undead unclean
         if (eDeity==ARAMON || eDeity==CERIS || eDeity==ARACHNUS || eRace==CAMBION)
@@ -1353,17 +1372,21 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
             return(true);
         if(enemy->isUndead())
             return(true);
+        break;
     case GRADIUS:
         if (eRace==ORC || eRace==GOBLIN || eRace==OGRE || eRace==TROLL || eRace==KOBOLD || eDeity==ARACHNUS || eDeity==ARAMON)
             return(true);
+        break;
     case ARES: 
         //Ares considers Ceris to be a cowardly pacifist whore...more importantly, she refuses to have sex with him :P
         if (eDeity==CERIS)
             return(true);
+        break;
     case KAMIRA: 
         //Kamira despises Jakar..because of his greed, and also because he's a stuck up tightwad that hates theiving
         if (eDeity==JAKAR || eDeity==ARAMON || eDeity==ARACHNUS)
             return(true);
+        break;
     case MARA:
     case LINOTHAN: 
         // Linothan and Mara hate Arachnus and Aramon, and also drow, orcs, goblins
@@ -1375,6 +1398,7 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
         //Both despise undead as abominations
         if(enemy->isUndead())
             return(true);
+        break;
     case ARACHNUS: 
         //Arachnus hates all good-aligned gods
         //And he of course hates all elves
@@ -1382,6 +1406,7 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
             return(true);
         if (eRace==ELF || eRace==WILDELF || eRace==GREYELF)
             return(true);
+        break;
     case JAKAR: 
         //Jakar has strong hatred for Kamira's thieving chaotic ways and always schemes to kill her or banish her to celestial jail
         //He hates tieflings because they are wired to be chaotic...and of course he also hates thieves
@@ -1393,6 +1418,7 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
         //Jakar cannot stand demons because they are 100% the definition of chaos..no god is more OCD than Jakar
         if (eMtype == DEMON) 
             return(true);
+        break;
     default:
         break;
     }// End Deity check
@@ -1407,67 +1433,79 @@ bool Creature::hatesEnemy(std::shared_ptr<Creature> enemy) const {
         //Druids also consider undead an abomination to nature
         if (enemy->isUndead())
             return(true);
+        break;
     case CreatureClass::RANGER:
         //Rangers hate undead as much as druids do
         if (enemy->isUndead())
             return(true);
         //TODO: If we ever add in ranger hated enemies...put check here
-
+        break;
     //TODO: Will remove the below 2 checks when afflictions are done and working. For now, keeping it simple
     case CreatureClass::PUREBLOOD:
         if (eClass == CreatureClass::WEREWOLF)
             return(true);
+        break;
     case CreatureClass::WEREWOLF:
         if (eClass == CreatureClass::PUREBLOOD)
             return(true);
+        break;
     default:
         break;
     }//end class checks
 
     // Finally we if we're a monster, we check our mtype for specific hatreds in case not caught by the above
-    // If we're a player, getType() will return PLAYER(0)..if we're an undefined mtype mob, it'll return MONSTER(1)
-    switch(getType()) {
-    case GIANTKIN:
-        // Giants hate dwarves
-        if (eRace == DWARF)
-            return(true);
-    case GOBLINOID:
-        // Pretty much all goblinoid races hate dwarves and elves
-        if (eRace==DWARF || eRace==ELF)
-            return(true);
-    case FAERIE:
-        // Evil fey hate elves
-        if (getAlignment() < 0 && (eRace==ELF || eRace==WILDELF || eRace==GREYELF))
-            return(true);
-        // Good fey hate drow, orcs, goblins
-        if (getAlignment() > 0 && (eRace==DARKELF || eRace==ORC || eRace==GOBLIN))
-            return(true);
-        // Extremely evil fey hate druids
-        if (getAdjustedAlignment() == BLOODRED && eClass == CreatureClass::DRUID)
-            return(true);
-        // Good and evil fey hate one another
-        if (eMtype == FAERIE && ((getAlignment() > 0 && eAlign < 0) || (getAlignment() < 0 && eAlign > 0)))
-            return(true);
-    case DEMON: // Demons hate devils and anything good aligned, as well as each another
-        if (eMtype == DEVIL || eMtype == DEMON)
-            return(true);
-        if (eAlign > 0)
-            return(true);
-    case DEVIL: // Devils hate demons and anything good aligned
-        if (eMtype == DEMON)
-            return(true);
-        if (eAlign > 0)
-            return(true);
-    case DEVA: // Devas (angels) hate devils and demons
-        if (eMtype == DEVIL || eMtype == DEMON)
-            return(true);
-    case UNDEAD: 
-        // Evil intelligent undead (only intelligent undead mobs are supposed to be mtype UNDEAD) hate CERIS, LINOTHAN, and ENOCH clerics/paladins
-        if (getAlignment() < 0 && (eDeity==CERIS || eDeity==LINOTHAN || eDeity==ENOCH))
-            return(true);
-    default:
-        break;
-    } // End check mtype
+    if (isMonster()) {
+        switch(getType()) {
+        case GIANTKIN:
+            // Giants hate dwarves
+            if (eRace == DWARF)
+                return(true);
+            break;
+        case GOBLINOID:
+            // Pretty much all goblinoid races hate dwarves and elves
+            if (eRace==DWARF || eRace==ELF)
+                return(true);
+            break;
+        case FAERIE:
+            // Evil fey hate elves
+            if (getAlignment() < 0 && (eRace==ELF || eRace==WILDELF || eRace==GREYELF))
+                return(true);
+            // Good fey hate drow, orcs, goblins
+            if (getAlignment() > 0 && (eRace==DARKELF || eRace==ORC || eRace==GOBLIN))
+                return(true);
+            // Extremely evil fey hate druids
+            if (getAdjustedAlignment() == BLOODRED && eClass == CreatureClass::DRUID)
+                return(true);
+            // Good and evil fey hate one another
+            if (eMtype == FAERIE && ((getAlignment() > 0 && eAlign < 0) || (getAlignment() < 0 && eAlign > 0)))
+                return(true);
+            break;
+        case DEMON: // Demons hate devils and anything good aligned, as well as each another
+            if (eMtype == DEVIL || eMtype == DEMON)
+                return(true);
+            if (eAlign > 0)
+                return(true);
+            break;
+        case DEVIL: // Devils hate demons and anything good aligned
+            if (eMtype == DEMON)
+                return(true);
+            if (eAlign > 0)
+                return(true);
+            break;
+        case DEVA: // Devas (angels) hate devils and demons
+            if (eMtype == DEVIL || eMtype == DEMON)
+                return(true);
+            break;
+        case UNDEAD: 
+            // Evil intelligent undead (only intelligent undead mobs are supposed to be mtype UNDEAD) hate CERIS, LINOTHAN, and ENOCH clerics/paladins
+            if (getAlignment() < 0 && (eDeity==CERIS || eDeity==LINOTHAN || eDeity==ENOCH))
+                return(true);
+            break;
+        default:
+            break;
+        } // End check mtype
+
+    }
     
 
     //Other checks...for effects..etc...

--- a/effects/effects.cpp
+++ b/effects/effects.cpp
@@ -992,7 +992,7 @@ bool Exit::doEffectDamage(const std::shared_ptr<Creature>& pTarget) {
     if( exitEffectDamage(
             getEffect("wall-of-fire"),
             pTarget, owner, FIRE, BURNED,
-            "The wall-of-fire burns you for %s%d^x damage.\n",
+            "^RThe wall-of-fire burns you for %s%d^x ^Rdamage.^x\n",
             "You are burned to death!\n",
             "%1M is engulfed by the wall-of-fire.\n%M burns to death!",
             "%M is engulfed by your wall-of-fire and is incinerated!\n"
@@ -1002,7 +1002,7 @@ bool Exit::doEffectDamage(const std::shared_ptr<Creature>& pTarget) {
     if( exitEffectDamage(
             getEffect("wall-of-thorns"),
             pTarget, owner, EARTH, THORNS,
-            "The wall-of=thorns stabs you for %s%d^x damage.\n",
+            "^yThe wall-of-thorns stabs you for %s%d^x ^ydamage.^x\n",
             "You are stabbed to death!\n",
             "%1M is engulfed by a wall-of-thorns.\n%M is stabbed to death!",
             "%M is engulfed by your wall-of-thorns and is stabbed to death!\n"
@@ -1012,7 +1012,7 @@ bool Exit::doEffectDamage(const std::shared_ptr<Creature>& pTarget) {
     if( exitEffectDamage(
             getEffect("wall-of-lightning"),
             pTarget, owner, ELEC, ELECTROCUTED,
-            "The wall-of-lightning zaps you for %s%d^x damage.\n",
+            "^cThe wall-of-lightning zaps you for %s%d^x ^cdamage.^x\n",
             "You are electrocuted to death!\n",
             "%1M is burned to a blackened husk by the wall-of-lightning.\n%M dies as a smoking corpse!",
             "%M is burned to a blackened husk by your wall-of-lightning and dies as a smoking corpse!\n"
@@ -1022,7 +1022,7 @@ bool Exit::doEffectDamage(const std::shared_ptr<Creature>& pTarget) {
     if( exitEffectDamage(
             getEffect("wall-of-sleet"),
             pTarget, owner, COLD, FROZEN_CUT,
-            "The wall-of-sleet slices and freezes you for %s%d^x damage.\n",
+            "^CThe wall-of-sleet slices and freezes you for %s%d^x ^Cdamage.^x\n",
             "You are cut to pieces by razory shards of ice! You died!\n",
             "%1M is sliced to pieces and frozen by the wall-of-sleet.\n%M dies a frozen bloody mess!",
             "%M is sliced to pieces and frozen by your wall-of-sleet and dies a frozen bloody mess!\n"

--- a/effects/effects.cpp
+++ b/effects/effects.cpp
@@ -881,7 +881,9 @@ std::string Effects::getEffectsString(const std::shared_ptr<Creature> & viewer) 
                 } else if(  (effectInfo->getDuration() == -1) && (
                     effectInfo->getName() == "wall-of-force" ||
                     effectInfo->getName() == "wall-of-fire" ||
-                    effectInfo->getName() == "wall-of-thorns"
+                    effectInfo->getName() == "wall-of-thorns" ||
+                    effectInfo->getName() == "wall-of-lightning" ||
+                    effectInfo->getName() == "wall-of-sleet"
                 ) ) {
                     // permanent walls are only down for a little bit
                     effStr << " (# pulses until reinstantiate)";
@@ -990,20 +992,40 @@ bool Exit::doEffectDamage(const std::shared_ptr<Creature>& pTarget) {
     if( exitEffectDamage(
             getEffect("wall-of-fire"),
             pTarget, owner, FIRE, BURNED,
-            "The wall of fire burns you for %s%d^x damage.\n",
+            "The wall-of-fire burns you for %s%d^x damage.\n",
             "You are burned to death!\n",
-            "%1M is engulfed by the wall of fire.\n%M burns to death!",
-            "%M is engulfed by your wall of fire and is incinerated!\n"
+            "%1M is engulfed by the wall-of-fire.\n%M burns to death!",
+            "%M is engulfed by your wall-of-fire and is incinerated!\n"
     ) )
         return(true);
 
     if( exitEffectDamage(
             getEffect("wall-of-thorns"),
             pTarget, owner, EARTH, THORNS,
-            "The wall of thorns stabs you for %s%d^x damage.\n",
+            "The wall-of=thorns stabs you for %s%d^x damage.\n",
             "You are stabbed to death!\n",
-            "%1M is engulfed by a wall of thorns.\n%M is stabbed to death!",
-            "%M is engulfed by your wall of thorns and is stabbed to death!\n"
+            "%1M is engulfed by a wall-of-thorns.\n%M is stabbed to death!",
+            "%M is engulfed by your wall-of-thorns and is stabbed to death!\n"
+    ) )
+        return(true);
+
+    if( exitEffectDamage(
+            getEffect("wall-of-lightning"),
+            pTarget, owner, ELEC, ELECTROCUTED,
+            "The wall-of-lightning zaps you for %s%d^x damage.\n",
+            "You are electrocuted to death!\n",
+            "%1M is burned to a blackened husk by the wall-of-lightning.\n%M dies as a smoking corpse!",
+            "%M is burned to a blackened husk by your wall-of-lightning and dies as a smoking corpse!\n"
+    ) )
+        return(true);
+
+    if( exitEffectDamage(
+            getEffect("wall-of-sleet"),
+            pTarget, owner, COLD, FROZEN_CUT,
+            "The wall-of-sleet slices and freezes you for %s%d^x damage.\n",
+            "You are cut to pieces by razory shards of ice! You died!\n",
+            "%1M is sliced to pieces and frozen by the wall-of-sleet.\n%M dies a frozen bloody mess!",
+            "%M is sliced to pieces and frozen by your wall-of-sleet and dies a frozen bloody mess!\n"
     ) )
         return(true);
 

--- a/effects/effectsLoader.cpp
+++ b/effects/effectsLoader.cpp
@@ -1564,8 +1564,30 @@ bool Config::loadEffects() {
       EffectBuilder()
         .name("wall-of-fire")
         .display("^rWall of Fire^x")
-        .roomAddStr("^RA wall of fire ignites and blocks passage to the *LOW-ACTOR*.^x")
-        .roomDelStr("^WThe wall of fire blocking the *LOW-ACTOR* dies down.^x")
+        .roomAddStr("^RA magical wall-of-fire ignites and blocks passage to the '*LOW-ACTOR*' exit.^x")
+        .roomDelStr("^WThe magical wall-of-fire blocking the '*LOW-ACTOR*' exit abruptly extinquishes.^x")
+        .pulsed(true)
+        .pulseScript("effectLib.pulseWall(actor, effect)")
+        .useStrength(true),
+      effects
+    );
+    addToSet(
+      EffectBuilder()
+        .name("wall-of-lightning")
+        .display("^cWall of Lightning^x")
+        .roomAddStr("^cA magical wall-of-lightning forms and blocks passage to the '*LOW-ACTOR*' exit.^x")
+        .roomDelStr("^WThe magical wall-of-lightning blocking the '*LOW-ACTOR*' exit has dissipated.^x")
+        .pulsed(true)
+        .pulseScript("effectLib.pulseWall(actor, effect)")
+        .useStrength(true),
+      effects
+    );
+    addToSet(
+      EffectBuilder()
+        .name("wall-of-sleet")
+        .display("^CWall of Sleet^x")
+        .roomAddStr("^CA magical wall-of-sleet forms and blocks passage to the '*LOW-ACTOR*' exit.^x")
+        .roomDelStr("^CThe magical wall-of-sleet blocking the '*LOW-ACTOR*' exit has faded away.^x")
         .pulsed(true)
         .pulseScript("effectLib.pulseWall(actor, effect)")
         .useStrength(true),
@@ -1574,9 +1596,9 @@ bool Config::loadEffects() {
     addToSet(
       EffectBuilder()
         .name("wall-of-force")
-        .display("^sWall of Force^x")
-        .roomAddStr("^sA wall of force appears and blocks passage to the *LOW-ACTOR*.^x")
-        .roomDelStr("^WThe wall of force blocking the *LOW-ACTOR* vanishes.^x")
+        .display("^MWall of Force^x")
+        .roomAddStr("^MA magical wall-of-force appears and blocks passage to the '*LOW-ACTOR*' exit.^x")
+        .roomDelStr("^WThe magical wall-of-force blocking the '*LOW-ACTOR*' exit abruptly vanishes.^x")
         .pulsed(true)
         .pulseScript("effectLib.pulseWall(actor, effect)"),
       effects

--- a/include/global.hpp
+++ b/include/global.hpp
@@ -492,6 +492,8 @@ enum DeathType {
     WOUNDED,
     CREEPING_DOOM,
     SUNLIGHT,
+    ELECTROCUTED,
+    FROZEN_CUT,
 
     // Trap death types
     PIT,

--- a/include/magic.hpp
+++ b/include/magic.hpp
@@ -264,9 +264,10 @@ std::string realmSkill(Realm realm);
 #define S_NONDETECTION          165 // non-detection spell
 #define S_BENEDICTION           166 // benediction spell
 #define S_MALEDICTION           167 // malediction spell
+#define S_WALL_OF_LIGHTNING     168 // wall-of-lightning spell
+#define S_WALL_OF_SLEET         169 // wall-of-sleet spell
 
-
-#define MAXSPELL                168 // Increment when you add a spell
+#define MAXSPELL                170 // Increment when you add a spell
 
 
 #define SpellFn const std::shared_ptr<Creature>&, cmd*, SpellData*
@@ -395,6 +396,10 @@ int splVigor(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spel
 int splWallOfFire(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);
 int splWallOfForce(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);
 int splWallOfThorns(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);
+int splWallOfLightning(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);
+int splWallOfSleet(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);
+int doWallSpell(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData, int strength, long duration);
+
 int splWarmth(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);
 int splWindProtection(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);
 int splWeakness(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData);

--- a/include/mudObjects/creatures.hpp
+++ b/include/mudObjects/creatures.hpp
@@ -513,6 +513,10 @@ public:
     bool doesntBreathe() const;
     bool immuneCriticals() const; // *
     bool isUndead() const; // *
+    bool isPureArcaneCaster() const;
+    bool isPureDivineCaster() const;
+    bool isHybridArcaneCaster() const;
+    bool isHybridDivineCaster() const;
     bool hasMp();
     bool isAntiGradius() const;
     bool countForWeightTrap() const;

--- a/include/mudObjects/exits.hpp
+++ b/include/mudObjects/exits.hpp
@@ -142,6 +142,11 @@ public:
     bool classRestrict(const std::shared_ptr<const Creature> &creature) const;
     bool clanRestrict(const std::shared_ptr<const Creature> &creature) const;
     bool alignRestrict(const std::shared_ptr<const Creature> &creature) const;
+    const char *hisHer() const;
+    const char *himHer() const;
+    const char *heShe() const;
+    const char *upHisHer() const;
+    const char *upHeShe() const; 
 };
 
 

--- a/magic/magic.cpp
+++ b/magic/magic.cpp
@@ -225,6 +225,8 @@ struct {
     { "non-detection",      S_NONDETECTION,         splNondetection,            30,         ABJURATION,         PROTECTION  },
     { "benediction",        S_BENEDICTION,          splBenediction,             20,         SCHOOL_CANNOT_CAST, PROTECTION        },
     { "malediction",        S_MALEDICTION,          splMalediction,             20,         SCHOOL_CANNOT_CAST, PROTECTION        },
+    { "wall-of-lightning",  S_WALL_OF_LIGHTNING,    splWallOfLightning,         30,         CONJURATION,        CREATION    },
+    { "wall-of-sleet",      S_WALL_OF_SLEET,        splWallOfSleet,             30,         CONJURATION,        CREATION    },
     { "@",                  -1,                     nullptr,                          0,          NO_SCHOOL,          NO_DOMAIN   }
 };
 int spllist_size = sizeof(spllist)/sizeof(*spllist);

--- a/magic/schools/abjuration.cpp
+++ b/magic/schools/abjuration.cpp
@@ -45,7 +45,6 @@
 #include "statistics.hpp"            // for Statistics
 #include "stats.hpp"                 // for Stat
 
-
 //*********************************************************************
 //                      protection from room damage spells
 //*********************************************************************
@@ -739,27 +738,21 @@ int splStoneskin(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* 
 
 int doDispelMagic(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData, const char* spell, int numDispel) {
     std::shared_ptr<Creature> target=nullptr;
+    EffectInfo* toDispel = nullptr;
+
     int     chance=0;
 
-    if(spellData->how == CastType::CAST &&
-        player->getClass() !=  CreatureClass::MAGE &&
-        player->getClass() !=  CreatureClass::LICH &&
-        player->getClass() !=  CreatureClass::CLERIC &&
-        player->getClass() !=  CreatureClass::DRUID &&
-        !player->isStaff()
-    ) {
-        player->print("Only mages, liches, clerics, and druids may cast that spell.\n");
+    if (!player->isStaff() && spellData->how == CastType::CAST && !(player->isPureArcaneCaster() || player->isPureDivineCaster())) {
+        *player << "Only mages, liches, clerics, and druids may cast that spell.\n";
         return(0);
     }
 
     if(cmnd->num == 2) {
         target = player;
+        
         broadcast(player->getSock(), player->getParent(), "%M casts a %s spell on %sself.", player.get(), spell, player->himHer());
-
-
-        player->print("You cast a %s spell on yourself.\n", spell);
-        player->print("Your spells begin to dissolve away.\n");
-
+        *player << "You cast a " << spell << " spell on yourself.\n";
+        *player << "Your spells begin to dissolve away.\n";
 
         player->doDispelMagic(numDispel);
     } else {
@@ -768,28 +761,72 @@ int doDispelMagic(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData*
 
         cmnd->str[2][0] = up(cmnd->str[2][0]);
         target = player->getParent()->findPlayer(player, cmnd, 2);
+
         if(!target) {
             // dispel-magic on an exit
             cmnd->str[2][0] = low(cmnd->str[2][0]);
             std::shared_ptr<Exit> exit = findExit(player, cmnd, 2);
-
             if(exit) {
-                player->printColor("You cast a %s spell on the %s^x.\n", spell, exit->getCName());
-                broadcast(player->getSock(), player->getParent(), "%M casts a %s spell on the %s^x.", player.get(), spell, exit->getCName());
-
-                if(exit->flagIsSet(X_PORTAL))
+                // Remove player-cast portal
+                if(exit->flagIsSet(X_PORTAL)) {
                     Move::deletePortal(player->getRoomParent(), exit);
+                    return(0);
+                }
+                std::string dispelStr = cmnd->str[3];
+                if (dispelStr.empty()) {
+                    *player << "Syntax: cast " << spell << " (exit) (effect)\n";
+                    *player << "Ex: cast " << spell << " door wall-of-fire\n";
+                    return(0);
+                }
+                if (dispelStr == "wall-of-force" && exit->getExactEffect(dispelStr)) {
+                    *player << "The " << spell << " spell is ineffective against a wall-of-force. You must use disintegrate.\n";
+                    return(0);
+                }
+               
+                if (!(toDispel = exit->getExactEffect(dispelStr))) {
+                    *player << "Effect " << dispelStr << " was not found on exit: " << exit->getCName() << ".\n";
+                    return(0);
+                }
                 else
-                    exit->doDispelMagic(player->getRoomParent());
+                {
+                    *player << "You cast a " << spell << " spell on the '" << exit->getCName() << "' exit.\n";
+                    broadcast(player->getSock(), player->getParent(), "%M casts a %s spell on the '%s' exit.^x", player.get(), spell, exit->getCName());
+                    if ((!toDispel->isOwner(player) && player->getLevel() < toDispel->getStrength()) && !player->isStaff()) {
+                        *player << "The " << dispelStr << " spell on the '" << exit->getCName() << "' exit is currently too powerful for you to remove.\n";
+                        broadcast(player->getSock(), player->getParent(), "%M's attempt to remove the %s from the '%s' exit failed.", player.get(), dispelStr.c_str(), exit->getCName());
+                        return(0);
+                    }
+                    //TODO: Determine if we want to check for matching effect on other side, and check against its strength also,
+                    //      as it's technically possible to have matching effects with differing strengths on either side...
+                    //      i.e. if a builder puts permanent walls of the same type but differing strengths on both sides
+                    
+                    *player << ColorOn << "You successfully removed the " << dispelStr << " spell from the '" << exit->getCName() << "' exit.\n" << ColorOff;
+                    broadcast(player->getSock(), player->getParent(), "%M successfully removed the %s spell from the '%s' exit.", player.get(), dispelStr.c_str(), exit->getCName());
+
+                    if (exit->isWall(toDispel->getName())) {
+                        if (toDispel->isPermanent()) {
+                            *player << "The magical " << dispelStr << " was very strong. The removal will only be temporary!\n";
+                            broadcast(player->getSock(), player->getParent(), "The magical %s was very strong. The removal will only be temporary!", dispelStr.c_str());
+                        }
+                        bringDownTheWall(toDispel, player->getRoomParent(), exit);
+                        
+                        
+                        return(0);
+                    }
+                    else
+                        exit->removeEffect(toDispel, true);
+                    
+                }
+
                 return(0);
             }
 
-            player->print("You don't see that player here.\n");
+            *player << "You don't see that player here.\n";
             return(0);
         }
 
         if(player->isPlayer() && player->getRoomParent()->isPkSafe() && (!player->isCt()) && !target->flagIsSet(P_OUTLAW)) {
-            player->print("That spell is not allowed here.\n");
+            *player << "That spell is not allowed here.\n";
             return(0);
         }
 
@@ -797,15 +834,15 @@ int doDispelMagic(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData*
             if(!player->canAttack(target))
                 return(0);
         } else {
-            player->print("You cast a %s spell on %N.\n%s body returns to flesh.\n", spell, target.get(), target->upHisHer());
+            *player << "You cast a " << spell << " spell on " << target.get() << ".\n" << target->upHisHer() << " body returns to flesh.\n";
             if(Random::get(1,100) < 50) {
+                *target << setf(CAP) << player << " casts a " << spell << " on you.\nYour body returns to flesh.\n";
 
-                target->print("%M casts a %s spell on you.\nYour body returns to flesh.\n", player.get(), spell);
                 broadcast(player->getSock(), target->getSock(), player->getParent(), "%M casts a %s spell on %N.\n%s body returns to flesh.\n", player.get(), spell, target.get(), target->upHisHer());
                 target->removeEffect("petrification");
                 return(1);
             } else {
-                target->print("%M casts a dispel-magic spell on you.\n", player.get());
+                *target << setf(CAP) << player << " casts a dispel-magic spell on you.\n";
                 broadcast(player->getSock(), target->getSock(), player->getParent(), "%M casts a dispel-magic spell on %N.\n",player.get(), target.get());
                 return(0);
             }
@@ -993,8 +1030,11 @@ void Creature::doDispelMagic(int num) {
 //*********************************************************************
 
 void Exit::doDispelMagic(const std::shared_ptr<BaseRoom>& parent) {
+
     bringDownTheWall(getEffect("wall-of-fire"), parent, shared_from_this());
     bringDownTheWall(getEffect("wall-of-thorns"), parent, shared_from_this());
+    bringDownTheWall(getEffect("wall-of-lightning"), parent, shared_from_this());
+    bringDownTheWall(getEffect("wall-of-sleet"), parent, shared_from_this());
 
     // true we'll show, false don't remove perm effects
     removeEffect("concealed", true, false);

--- a/magic/schools/conjuration.cpp
+++ b/magic/schools/conjuration.cpp
@@ -983,11 +983,11 @@ int splWallOfFire(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData*
 
     if(!player->isCt()) {
         if(player->getRoomParent()->isPkSafe()) {
-            player->print("That spell is not allowed here.\n");
+            *player << "That spell is not allowed here.\n";
             return(0);
         }
         if(player->getRoomParent()->isUnderwater()) {
-            player->print("Water currents prevent you from casting that spell.\n");
+            *player << "Water currents prevent you from casting that spell.\n";
             return(0);
         }
     }
@@ -995,22 +995,26 @@ int splWallOfFire(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData*
     if(cmnd->num > 2)
         exit = findExit(player, cmnd, 2);
     if(!exit) {
-        player->print("Cast a wall of fire on which exit?\n");
+        *player << "Cast a wall of fire on which exit?\n";
         return(0);
     }
 
-    player->printColor("You cast a wall of fire spell on the %s^x.\n", exit->getCName());
-    broadcast(player->getSock(), player->getParent(), "%M casts a wall of fire spell on the %s^x.", player.get(), exit->getCName());
+    *player << ColorOn << "^RYou cast a wall of fire in front of the " << exit->getCName() << " exit.\n" << ColorOff;
+    
+
+    broadcast(player->getSock(), player->getParent(), "%M casts a wall of fire spell in front of the '%s' exit.", player.get(), exit->getCName());
 
     if(exit->hasPermEffect("wall-of-fire")) {
-        player->print("The spell didn't take hold.\n");
+        *player << "The spell didn't take hold.\n";
         return(0);
     }
+
 
     if(spellData->how == CastType::CAST) {
         if(player->getRoomParent()->magicBonus())
-            player->print("The room's magical properties increase the power of your spell.\n");
+            *player << "The room's magical properties increase the power of your spell.\n";
     }
+
 
     exit->addEffectReturnExit("wall-of-fire", duration, strength, player);
     return(1);
@@ -1031,21 +1035,21 @@ int splWallOfForce(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData
     if(cmnd->num > 2)
         exit = findExit(player, cmnd, 2);
     if(!exit) {
-        player->print("Cast a wall of force on which exit?\n");
+        *player << "Cast a wall of force on which exit?\n";
         return(0);
     }
 
-    player->printColor("You cast a wall of force spell on the %s^x.\n", exit->getCName());
-    broadcast(player->getSock(), player->getParent(), "%M casts a wall of force spell on the %s^x.", player.get(), exit->getCName());
+    *player << ColorOn << "^MYou cast a wall of force spell in front of the '" << exit->getCName() << "' exit.\n" << ColorOff;
+    broadcast(player->getSock(), player->getParent(), "%M casts a wall of force spell in front of the '%s' exit.", player.get(), exit->getCName());
 
     if(exit->hasPermEffect("wall-of-force")) {
-        player->print("The spell didn't take hold.\n");
+        *player << "The spell didn't take hold.\n";
         return(0);
     }
 
     if(spellData->how == CastType::CAST) {
         if(player->getRoomParent()->magicBonus())
-            player->print("The room's magical properties increase the power of your spell.\n");
+            *player << "The room's magical properties increase the power of your spell.\n";
     }
 
     exit->addEffectReturnExit("wall-of-force", duration, strength, player);
@@ -1065,28 +1069,28 @@ int splWallOfThorns(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellDat
         return(0);
 
     if(player->getRoomParent()->isPkSafe() && !player->isCt()) {
-        player->print("That spell is not allowed here.\n");
+        *player << "That spell is not allowed here.\n";
         return(0);
     }
 
     if(cmnd->num > 2)
         exit = findExit(player, cmnd, 2);
     if(!exit) {
-        player->print("Cast a wall of thorns on which exit?\n");
+        *player << "Cast a wall of thorns on which exit?\n";
         return(0);
     }
 
-    player->printColor("You cast a wall of thorns spell on the %s^x.\n", exit->getCName());
-    broadcast(player->getSock(), player->getParent(), "%M casts a wall of thorns spell on the %s^x.", player.get(), exit->getCName());
+    *player << ColorOn << "^yYou cast a wall of thorns spell in front of the '" << exit->getCName() << "' exit.\n" << ColorOff;
+    broadcast(player->getSock(), player->getParent(), "%M casts a wall of thorns spell in front of the '%s' exit.", player.get(), exit->getCName());
 
     if(exit->hasPermEffect("wall-of-thorns")) {
-        player->print("The spell didn't take hold.\n");
+        *player << "The spell didn't take hold.\n";
         return(0);
     }
 
     if(spellData->how == CastType::CAST) {
         if(player->getRoomParent()->magicBonus())
-            player->print("The room's magical properties increase the power of your spell.\n");
+            *player << "The room's magical properties increase the power of your spell.\n";
     }
 
     exit->addEffectReturnExit("wall-of-thorns", duration, strength, player);

--- a/magic/schools/conjuration.cpp
+++ b/magic/schools/conjuration.cpp
@@ -23,6 +23,7 @@
 #include <type_traits>               // for enable_if<>::type
 
 #include "cmd.hpp"                   // for cmd
+#include "color.hpp"                 // for stripColor
 #include "dice.hpp"                  // for Dice
 #include "effects.hpp"               // for EffectInfo, Effect
 #include "flags.hpp"                 // for M_PLUS_TWO, M_ENCHANTED_WEAPONS_...
@@ -943,11 +944,11 @@ int splToxicCloud(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData*
 
     if(!player->isCt()) {
         if(player->getRoomParent()->isPkSafe()) {
-            player->print("That spell is not allowed here.\n");
+            player->print("This is a safe room. That spell is not allowed here.\n");
             return(0);
         }
         if(player->getRoomParent()->isUnderwater()) {
-            player->print("Water currents prevent you from casting that spell.\n");
+            player->print("Strong water currents prevent you from casting that spell.\n");
             return(0);
         }
     }
@@ -969,91 +970,182 @@ int splToxicCloud(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData*
     return(1);
 }
 
+//******************************************************************************************************
+//                      doWallSpell
+//******************************************************************************************************
+int doWallSpell(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData, const char * wallSpell, int strength, long duration) {
+    std::shared_ptr<Exit> exit=nullptr;
+    std::shared_ptr<BaseRoom> targetRoom=nullptr;
+
+    if(player->noPotion(spellData))
+        return(0);
+
+    if(player->getRoomParent()->isPkSafe() && !player->isCt()) {
+            *player << "This is a safe room. That spell is not allowed here.\n";
+            return(0);
+        }
+
+    if(cmnd->num > 2)
+        exit = findExit(player, cmnd, 2);
+    if(!exit) {
+        *player << ColorOn << "Cast "<< wallSpell << " on which exit?\n" << ColorOff;
+        return(0);
+    }
+
+    targetRoom = exit->target.loadRoom();
+    if (!targetRoom) {
+        *player << "Your spell fizzled.\n";
+        return(0);
+    }
+    if (targetRoom->isPkSafe()) {
+        *player << "That spell is not allowed here. The room beyond the '" << exit->getCName() << "' exit is a safe room.\n";
+        return(0);
+    }
+
+    bool wallReplace=false;
+    if (exit->isEffected(stripColor(wallSpell))) {
+       auto* effInfo = exit->getEffect(stripColor(wallSpell));
+
+        if (!player->isCt() && ((effInfo->getStrength() > strength) || (exit->hasPermEffect(stripColor(wallSpell))))) {
+            *player << ColorOn << "The existing " << wallSpell << " on the '" << exit->getCName() << "' exit is too strong for you to replace.\nYour spell fizzled.\n" << ColorOff;
+            broadcast(player->getSock(), player->getParent(), "%M tried to cast a %s spell in front of the '%s' exit. %s spell fizzled.^x", player.get(), wallSpell, exit->getCName(), player->upHisHer());
+            return(0);
+       }
+       else 
+            wallReplace=true;      
+    }
+    if (wallReplace) {
+        *player << "You cast a new " << wallSpell << " to replace the one in front of the '" << exit->getCName() << "' exit.\n";
+        broadcast(player->getSock(), player->getParent(), "%M casts a new %s spell to replace the one in front of the '%s' exit.^x", player.get(), wallSpell, exit->getCName());
+    }
+    else 
+    {
+        *player << "You cast a " << wallSpell << " in front of the '" << exit->getCName() << "' exit.\n";
+        broadcast(player->getSock(), player->getParent(), "%M casts a %s spell in front of the '%s' exit.^x", player.get(), wallSpell, exit->getCName());
+    }
+    
+    if(spellData->how == CastType::CAST) {
+        if(player->getRoomParent()->magicBonus())
+            *player << "The room's magical properties increase the power of your spell.\n";
+    }
+
+    if (wallReplace)
+        exit->removeEffectReturnExit(stripColor(wallSpell), player->getRoomParent());
+
+    exit->addEffectReturnExit(stripColor(wallSpell), duration, strength, player);
+    return(1);
+
+}
+
 //*********************************************************************
 //                      splWallOfFire
 //*********************************************************************
 
 int splWallOfFire(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData) {
-    std::shared_ptr<Exit> exit=nullptr;
     int strength = spellData->level;
-    long duration = 300;
-
-    if(player->noPotion( spellData))
-        return(0);
+    long duration = (long)strength * 15;
 
     if(!player->isCt()) {
-        if(player->getRoomParent()->isPkSafe()) {
-            *player << "That spell is not allowed here.\n";
+        if (!player->isPureArcaneCaster() && !player->isPureDivineCaster()) {
+            *player << "You lack the arcane or divine fundamentals to cast that spell.\n";
             return(0);
         }
         if(player->getRoomParent()->isUnderwater()) {
-            *player << "Water currents prevent you from casting that spell.\n";
+            *player << "Being underwater prevents you from casting that spell here.\n";
+            return(0);
+        }
+
+    }
+    if (player->getRoomParent()->flagIsSet(R_COLD_BONUS) || player->getRoomParent()->flagIsSet(R_WINTER_COLD))
+        duration = (duration*2)/3;
+    if (player->getRoomParent()->flagIsSet(R_WATER_BONUS))
+        duration /= 2;
+    if (player->getRoomParent()->flagIsSet(R_FIRE_BONUS))
+        duration *= 2;
+
+    if (player->getClass() == CreatureClass::DRUID)
+        duration = (duration*3)/2;
+
+    return(doWallSpell(player, cmnd, spellData, "^Rwall-of-fire^x", strength, duration));
+}
+
+//*********************************************************************
+//                      splWallOfSleet
+//*********************************************************************
+
+int splWallOfSleet(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData) {
+    int strength = spellData->level;
+    long duration = (long)strength * 15;
+
+    if(!player->isCt()) {
+        if (!player->isPureArcaneCaster() && !player->isPureDivineCaster()) {
+            *player << "You lack the arcane or divine fundamentals to cast that spell.\n";
+            return(0);
+        }
+        if(player->getRoomParent()->isUnderwater()) {
+            *player << "Being underwater prevents you from casting that spell here.\n";
+            return(0);
+        }
+
+    }
+    if (player->getRoomParent()->flagIsSet(R_FIRE_BONUS) && player->getRoomParent()->flagIsSet(R_PLAYER_HARM))
+        duration = (duration*2)/3;
+    if (player->getRoomParent()->flagIsSet(R_FIRE_BONUS) || (player->getRoomParent()->flagIsSet(R_DESERT_HARM) && isDay()))
+        duration /= 2;
+    if (player->getRoomParent()->flagIsSet(R_COLD_BONUS))
+        duration *= 2;
+
+    if (player->getClass() == CreatureClass::DRUID)
+        duration = (duration*3)/2;
+
+    return(doWallSpell(player, cmnd, spellData, "^Cwall-of-sleet^x", strength, duration));
+}
+
+//*********************************************************************
+//                      splWallOfLightning
+//*********************************************************************
+
+int splWallOfLightning(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData) {
+    int strength = spellData->level;
+    long duration = (long)strength * 15;
+
+    if(!player->isCt()) {
+        if (!player->isPureArcaneCaster() && !player->isPureDivineCaster()) {
+            *player << "You lack the arcane or divine fundamentals to cast that spell.\n";
+            return(0);
+        }
+        if(player->getRoomParent()->isUnderwater()) {
+            *player << ColorOn << "^#^cThe massive amount of water surrounding you diffuses the electricity with a loud BANG!\n" << ColorOff;
+            broadcast(player->getSock(), player->getParent(), "^#^c%M tried to cast a ^cwall-of-lightning^x spell. The surrounding water diffused it with a loud BANG!^x", player.get());
             return(0);
         }
     }
 
-    if(cmnd->num > 2)
-        exit = findExit(player, cmnd, 2);
-    if(!exit) {
-        *player << "Cast a wall of fire on which exit?\n";
-        return(0);
-    }
+    if (player->getRoomParent()->flagIsSet(R_WATER_BONUS))
+        duration /= 2;
+    if (player->getRoomParent()->flagIsSet(R_ELEC_BONUS))
+        duration *= 2;
+    if (player->getClass() == CreatureClass::DRUID)
+        duration = (duration*3)/2;
 
-    *player << ColorOn << "^RYou cast a wall of fire in front of the " << exit->getCName() << " exit.\n" << ColorOff;
-    
-
-    broadcast(player->getSock(), player->getParent(), "%M casts a wall of fire spell in front of the '%s' exit.", player.get(), exit->getCName());
-
-    if(exit->hasPermEffect("wall-of-fire")) {
-        *player << "The spell didn't take hold.\n";
-        return(0);
-    }
-
-
-    if(spellData->how == CastType::CAST) {
-        if(player->getRoomParent()->magicBonus())
-            *player << "The room's magical properties increase the power of your spell.\n";
-    }
-
-
-    exit->addEffectReturnExit("wall-of-fire", duration, strength, player);
-    return(1);
+    return(doWallSpell(player, cmnd, spellData, "^cwall-of-lightning^x", strength, duration));
 }
 
 //*********************************************************************
 //                      splWallOfForce
 //*********************************************************************
-
 int splWallOfForce(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData) {
-    std::shared_ptr<Exit> exit=nullptr;
     int strength = spellData->level;
-    long duration = 300;
+    long duration = (long)strength * 15;
 
-    if(player->noPotion( spellData))
-        return(0);
 
-    if(cmnd->num > 2)
-        exit = findExit(player, cmnd, 2);
-    if(!exit) {
-        *player << "Cast a wall of force on which exit?\n";
+    if(!player->isCt() && !player->isPureArcaneCaster()) {
+        *player << "You lack the arcane fundamentals to cast that spell.\n";
         return(0);
     }
 
-    *player << ColorOn << "^MYou cast a wall of force spell in front of the '" << exit->getCName() << "' exit.\n" << ColorOff;
-    broadcast(player->getSock(), player->getParent(), "%M casts a wall of force spell in front of the '%s' exit.", player.get(), exit->getCName());
 
-    if(exit->hasPermEffect("wall-of-force")) {
-        *player << "The spell didn't take hold.\n";
-        return(0);
-    }
-
-    if(spellData->how == CastType::CAST) {
-        if(player->getRoomParent()->magicBonus())
-            *player << "The room's magical properties increase the power of your spell.\n";
-    }
-
-    exit->addEffectReturnExit("wall-of-force", duration, strength, player);
-    return(1);
+    return(doWallSpell(player, cmnd, spellData, "^Mwall-of-force^x", strength, duration));
 }
 
 //*********************************************************************
@@ -1061,40 +1153,19 @@ int splWallOfForce(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData
 //*********************************************************************
 
 int splWallOfThorns(const std::shared_ptr<Creature>& player, cmd* cmnd, SpellData* spellData) {
-    std::shared_ptr<Exit> exit=nullptr;
     int strength = spellData->level;
-    long duration = 300;
+    long duration = (long)strength * 15;
 
-    if(player->noPotion( spellData))
-        return(0);
-
-    if(player->getRoomParent()->isPkSafe() && !player->isCt()) {
-        *player << "That spell is not allowed here.\n";
-        return(0);
+     if(!player->isCt()) {
+        if (player->getClass() != CreatureClass::DRUID && player->getClass() != CreatureClass::RANGER &&
+            !(player->getClass() == CreatureClass::CLERIC && (player->getDeity() == LINOTHAN || player->getDeity() == MARA))) {
+            *player << "Only druids, rangers, and clerics of Linothan or Mara can cast that spell.\n";
+            return(0);
+        }
     }
 
-    if(cmnd->num > 2)
-        exit = findExit(player, cmnd, 2);
-    if(!exit) {
-        *player << "Cast a wall of thorns on which exit?\n";
-        return(0);
-    }
-
-    *player << ColorOn << "^yYou cast a wall of thorns spell in front of the '" << exit->getCName() << "' exit.\n" << ColorOff;
-    broadcast(player->getSock(), player->getParent(), "%M casts a wall of thorns spell in front of the '%s' exit.", player.get(), exit->getCName());
-
-    if(exit->hasPermEffect("wall-of-thorns")) {
-        *player << "The spell didn't take hold.\n";
-        return(0);
-    }
-
-    if(spellData->how == CastType::CAST) {
-        if(player->getRoomParent()->magicBonus())
-            *player << "The room's magical properties increase the power of your spell.\n";
-    }
-
-    exit->addEffectReturnExit("wall-of-thorns", duration, strength, player);
-    return(1);
+    
+    return(doWallSpell(player, cmnd, spellData, "^ywall-of-thorns^x", strength, duration));
 }
 
 //*********************************************************************
@@ -1108,18 +1179,23 @@ void bringDownTheWall(EffectInfo* effect, const std::shared_ptr<BaseRoom>& room,
     std::shared_ptr<BaseRoom> targetRoom=nullptr;
     std::string name = effect->getName();
 
+    targetRoom = exit->target.loadRoom();
+    if (!targetRoom)
+        return;
+
     if(effect->isPermanent()) {
         // fake being removed
         auto* ef = effect->getEffect();
-        room->effectEcho(ef->getRoomAddStr(), exit);
+        room->effectEcho(ef->getRoomDelStr(), exit);
 
         // extra of 2 means a 2 pulse (21-40 seconds) duration
         effect->setExtra(2);
+
         exit = exit->getReturnExit(room, targetRoom);
         if(exit) {
             effect = exit->getEffect(name);
             if(effect) {
-                targetRoom->effectEcho(ef->getRoomAddStr(), exit);
+                targetRoom->effectEcho(ef->getRoomDelStr(), exit);
                 effect->setExtra(2);
             }
         }

--- a/movement/exits.cpp
+++ b/movement/exits.cpp
@@ -41,6 +41,7 @@
 #include "mudObjects/uniqueRooms.hpp"            // for UniqueRoom
 #include "proto.hpp"                             // for zero, broadcast, fin...
 #include "size.hpp"                              // for NO_SIZE, Size
+#include "mud.hpp"                               // for LT_SPELL
 
 //*********************************************************************
 //                      Exit
@@ -455,13 +456,12 @@ bool Player::showExit(const std::shared_ptr<Exit>& exit, int magicShowHidden) co
 void Exit::addEffectReturnExit(const std::string &effect, long duration, int strength, const std::shared_ptr<Creature> & owner) {
     std::shared_ptr<BaseRoom> targetRoom=nullptr;
 
-
-    addEffect(effect, duration, strength, nullptr, true, owner); 
+    addEffect(effect, duration, strength, nullptr, true, owner);
 
     targetRoom = target.loadRoom();
-    if (!targetRoom)
+    if (!targetRoom) 
         return;
-    
+
     // switch the meaning of exit
     std::shared_ptr<Exit> exit = getReturnExit(owner->getConstRoomParent(), targetRoom);
     if(exit)
@@ -481,7 +481,7 @@ void Exit::removeEffectReturnExit(const std::string &effect, const std::shared_p
     targetRoom = target.loadRoom();
     if (!targetRoom)
         return;
-    
+
     // switch the meaning of exit
     std::shared_ptr<Exit> exit = getReturnExit(rParent, targetRoom);
     if(exit)
@@ -596,4 +596,44 @@ std::string getDirName(Direction dir) {
     default:
         return("none");
     }
+}
+
+//*********************************************************************
+//                      hisHer
+//*********************************************************************
+
+const char *Exit::hisHer() const {
+    return("it");
+}
+
+//*********************************************************************
+//                      himHer
+//*********************************************************************
+
+const char *Exit::himHer() const {
+    return("it");
+}
+
+//*********************************************************************
+//                      heShe
+//*********************************************************************
+
+const char *Exit::heShe() const {
+    return("it");
+}
+
+//*********************************************************************
+//                      upHisHer
+//*********************************************************************
+
+const char *Exit::upHisHer() const {
+    return("It");
+}
+
+//*********************************************************************
+//                      upHeShe
+//*********************************************************************
+
+const char *Exit::upHeShe() const {
+    return("It");
 }

--- a/movement/exits.cpp
+++ b/movement/exits.cpp
@@ -455,7 +455,13 @@ bool Player::showExit(const std::shared_ptr<Exit>& exit, int magicShowHidden) co
 void Exit::addEffectReturnExit(const std::string &effect, long duration, int strength, const std::shared_ptr<Creature> & owner) {
     std::shared_ptr<BaseRoom> targetRoom=nullptr;
 
-    addEffect(effect, duration, strength, nullptr, true, owner);
+
+    addEffect(effect, duration, strength, nullptr, true, owner); 
+
+    targetRoom = target.loadRoom();
+    if (!targetRoom)
+        return;
+    
     // switch the meaning of exit
     std::shared_ptr<Exit> exit = getReturnExit(owner->getConstRoomParent(), targetRoom);
     if(exit)
@@ -472,6 +478,10 @@ void Exit::removeEffectReturnExit(const std::string &effect, const std::shared_p
     std::shared_ptr<BaseRoom> targetRoom=nullptr;
 
     removeEffect(effect, true, false);
+    targetRoom = target.loadRoom();
+    if (!targetRoom)
+        return;
+    
     // switch the meaning of exit
     std::shared_ptr<Exit> exit = getReturnExit(rParent, targetRoom);
     if(exit)

--- a/python/mudObject.cpp
+++ b/python/mudObject.cpp
@@ -93,6 +93,11 @@ void init_module_mudObject(py::module &m) {
 
     py::class_<Exit, MudObject, std::shared_ptr<Exit> >(m, "Exit")
         .def("getRoom", &Exit::getRoom, py::return_value_policy::reference)
+        .def("hisHer", &Exit::hisHer, py::return_value_policy::reference)
+        .def("himHer", &Exit::himHer, py::return_value_policy::reference)
+        .def("heShe", &Exit::heShe, py::return_value_policy::reference)
+        .def("upHisHer", &Exit::upHisHer, py::return_value_policy::reference)
+        .def("upHeShe", &Exit::upHeShe, py::return_value_policy::reference)
     ;
 
 

--- a/roguelike/rogues.cpp
+++ b/roguelike/rogues.cpp
@@ -274,11 +274,15 @@ void doSearch(std::shared_ptr<Player> player, bool immediate) {
                 player->printColor("You found an exit: %s^x.\n", ext->getCName());
 
                 if(ext->isWall("wall-of-fire"))
-                    player->printColor("%s", ext->blockedByStr('R', "wall of fire", "wall-of-fire", detectMagic, true).c_str());
+                    player->printColor("%s", ext->blockedByStr('R', "wall-of-fire", "wall-of-fire", detectMagic, true).c_str());
                 if(ext->isWall("wall-of-force"))
-                    player->printColor("%s", ext->blockedByStr('s', "wall of force", "wall-of-force", detectMagic, true).c_str());
+                    player->printColor("%s", ext->blockedByStr('M', "wall-of-force", "wall-of-force", detectMagic, true).c_str());
                 if(ext->isWall("wall-of-thorns"))
-                    player->printColor("%s", ext->blockedByStr('o', "wall of thorns", "wall-of-thorns", detectMagic, true).c_str());
+                    player->printColor("%s", ext->blockedByStr('y', "wall-of-thorns", "wall-of-thorns", detectMagic, true).c_str());
+                if(ext->isWall("wall-of-lightning"))
+                    player->printColor("%s", ext->blockedByStr('c', "wall-of-lightning", "wall-of-lightning", detectMagic, true).c_str());
+                if(ext->isWall("wall-of-sleet"))
+                    player->printColor("%s", ext->blockedByStr('C', "wall-of-sleet", "wall-of-sleet", detectMagic, true).c_str());
             }
         }
     }
@@ -769,6 +773,10 @@ int cmdScout(const std::shared_ptr<Player>& player, cmd* cmnd) {
         if(exit->isEffected("wall-of-fire"))
             chance -= 15;
         if(exit->isEffected("wall-of-thorns"))
+            chance -= 15;
+        if(exit->isEffected("wall-of-lightning"))
+            chance -= 15;
+        if(exit->isEffected("wall-of-sleet"))
             chance -= 15;
 
         chance = std::min(85, chance);

--- a/staff/dmcrt.cpp
+++ b/staff/dmcrt.cpp
@@ -1126,10 +1126,10 @@ int dmSetCrt(const std::shared_ptr<Player>& player, cmd* cmnd) {
 
             std::string txt = getFullstrText(cmnd->fullstr, 5);
             if(!txt.empty())
-                duration = toNum<long>(txt);
+                duration = (long)std::stoi(txt);
             txt = getFullstrText(cmnd->fullstr, 6);
             if(!txt.empty())
-                strength = toNum<int>(txt);
+                strength = std::stoi(txt);
 
             if(duration > EFFECT_MAX_DURATION || duration < -1) {
                 player->print("Duration must be between -1 and %d.\n", EFFECT_MAX_DURATION);

--- a/staff/dmroom.cpp
+++ b/staff/dmroom.cpp
@@ -1185,10 +1185,10 @@ int dmSetRoom(const std::shared_ptr<Player>& player, cmd* cmnd) {
 
             std::string txt = getFullstrText(cmnd->fullstr, 4);
             if(!txt.empty())
-                duration = toNum<long>(txt);
+                duration = (long)std::stoi(txt);
             txt = getFullstrText(cmnd->fullstr, 5);
             if(!txt.empty())
-                strength = toNum<int>(txt);
+                strength = std::stoi(txt);
 
             if(duration > EFFECT_MAX_DURATION || duration < -1) {
                 player->print("Duration must be between -1 and %d.\n", EFFECT_MAX_DURATION);
@@ -1625,10 +1625,11 @@ int dmSetExit(const std::shared_ptr<Player>& player, cmd* cmnd) {
 
                 std::string txt = getFullstrText(cmnd->fullstr, 4);
                 if(!txt.empty())
-                    duration = toNum<long>(txt);
+                    duration = (long)std::stoi(txt);
+                
                 txt = getFullstrText(cmnd->fullstr, 5);
                 if(!txt.empty())
-                    strength = toNum<int>(txt);
+                    strength = std::stoi(txt);
 
                 if(duration > EFFECT_MAX_DURATION || duration < -1) {
                     player->print("Duration must be between -1 and %d.\n", EFFECT_MAX_DURATION);


### PR DESCRIPTION
-Fixes game crash nullptr bug where the wall spells and the knock command were crashing it
-Adds functionality for dispel command to dispel player owned exit and room effects
-Fixes python functionality around permanent exit effects temporarily being dispelled
-Fixes and adds functionality to dispel-magic around exit effects, and also for disintegrate on the wall-of-force exit effect
-Fixes *set xef, *set r eff, and *set c mob eff to again allow setting effects on exits and rooms in game
-Adds wall-of-lightning and wall-of-sleet spells/effects

TODO still:
-Add wall-of-iron, wall-of-ice, and wall-of-stone spells/effects (maybe others)
-Add functionality to dispel-magic to work on room effects
-Adjust/add possible mitigations on where the wall spells can be cast, perhaps using exit size as a basis
