### PR TITLE
fix hp and mp bonuses from con and int (focus broken)

### DIFF
--- a/creatures/creatureAttr.cpp
+++ b/creatures/creatureAttr.cpp
@@ -516,9 +516,11 @@ void Creature::crtReset() {
     hp.setName("Hp");
     mp.setName("Mp");
 
-    auto* pThis = dynamic_cast<Player*>(this);
-    if(pThis) {
-        pThis->focus.setName("Focus");
+    if(isPlayer()) {
+        auto* pThis = dynamic_cast<Player*>(this);
+        if (pThis) {
+            pThis->focus.setName("Focus");
+        }
 
         constitution.setInfluences(&hp);
         hp.setInfluencedBy(&constitution);


### PR DESCRIPTION
Fixes the hp bonus from con and the mp bonus from int, but leaves focus broken still. Using `getAsPlayer()` throws a `bad_weak_ptr` and only `Player` has the focus stat defined.