### PR TITLE
misc bug fixes after last update

### DIFF
--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,7 +21,7 @@
 #define VERSION_MINOR "6"
 
 
-#define VERSION_SUB "1b"
+#define VERSION_SUB "1c"
 
 
 #define VERSION VERSION_MAJOR "." VERSION_MINOR VERSION_SUB

--- a/magic/divine/healers.cpp
+++ b/magic/divine/healers.cpp
@@ -1144,12 +1144,8 @@ int doDivineWords(const std::shared_ptr<Player>& player, cmd* cmnd, const std::s
         }
     }
 
-    target = player->getParent()->findCreature(player, cmnd->str[1], cmnd->val[1], false);
-
-    if (!target) {
-        *player << "You don't see that target here.\n";
+    if(!(target = player->findVictim(cmnd, 1, true, false, (holy?"Holyword whom?\n":"Unholyword whom?\n"), "You don't see that here.\n")))
         return(0);
-    }
 
     double level = player->getSkillLevel(holy?"holyword":"unholyword");
 
@@ -1336,7 +1332,7 @@ int doDivineWords(const std::shared_ptr<Player>& player, cmd* cmnd, const std::s
             }
         }
 
-        *player << ColorOn << (holy?"^W":"^D") << gConfig->getDeity(player->getDeity())->getName() << "'s " << (saved?"enervated":"") << " " << (holy?"holy":"unholy") 
+        *player << ColorOn << (holy?"^W":"^D") << gConfig->getDeity(player->getDeity())->getName() << "'s " << (saved?"enervated ":"") << (holy?"holy":"unholy") 
                                                          << " word does " << (holy?"^Y":"^R") << dmg << (holy?"^W":"^D") << " divine damage to " << target << ".\n" << ColorOff;
 
         *target << ColorOn << (holy?"^W":"^D") << "The divine power of " << gConfig->getDeity(player->getDeity())->getName() << " " << (saved?"tears at":"savages") << " your soul for " 

--- a/xml/creatures-xml.cpp
+++ b/xml/creatures-xml.cpp
@@ -438,8 +438,20 @@ int Creature::readFromXml(xmlNodePtr rootNode, bool offline) {
             }
 
             if (getVersion() < "2.61b") {
-                if (getClass() == CreatureClass::CLERIC && getDeity() == ARAMON && getLevel() >=10)
+                if (getClass() == CreatureClass::CLERIC && getDeity() == ARAMON && level >= 10 && getAsPlayer()->getSecondClass() == CreatureClass::NONE)
                     addSkill("unholyword",std::max<int>(1,(level*30)/4));
+            }
+
+            //Multi-class clerics (like cleric/assassins) weren't supposed to get unholyword. Ooops....This fixes that.
+            if(getVersion() < "2.61c") {
+                if (getClass() == CreatureClass::CLERIC && getAsPlayer()->getSecondClass() != CreatureClass::NONE && knowsSkill("unholyword"))
+                    remSkill("unholyword");
+
+                // Bring Enoch clerics up to snuff with holyword, since they've been suffering with it being broken for so long
+                if (getClass() == CreatureClass::CLERIC && getAsPlayer()->getSecondClass() == CreatureClass::NONE && knowsSkill("holyword")) {
+                    if (getSkillGained("holyword") < ((level*30)/4))
+                        setSkill("holyword", ((level*30)/4));
+                }
             }
             
         }


### PR DESCRIPTION
-Cleric/Assassins were mistakenly given unholyword. Fixes that.
-Fixes targeting in holyword/unholyword so it functions properly 
-Enoch clerics with holyword will get a skill level bump to 75% of max if they are currently below that. 
-Bumped version