### PR TITLE
Gtarget and misc

### DIFF
--- a/combat/threat.cpp
+++ b/combat/threat.cpp
@@ -356,7 +356,7 @@ void Creature::checkTarget(const std::shared_ptr<Creature>& toTarget) {
 //                          addTarget
 //*********************************************************************
 
-std::shared_ptr<Creature> Creature::addTarget(const std::shared_ptr<Creature>& toTarget) {
+std::shared_ptr<Creature> Creature::addTarget(const std::shared_ptr<Creature>& toTarget, bool suppressGroupTargetMsg) {
     if(!toTarget)
         return(nullptr);
 
@@ -367,12 +367,19 @@ std::shared_ptr<Creature> Creature::addTarget(const std::shared_ptr<Creature>& t
 
     clearTarget();
 
+
     toTarget->addTargetingThis(Containable::downcasted_shared_from_this<Creature>());
     myTarget = toTarget;
 
     std::shared_ptr<Player> ply = getAsPlayer();
+    Group* group = getAsPlayer()->getGroup(true);
+
     if(ply) {
         ply->printColor("You are now targeting %s.\n", toTarget->getCName());
+
+        if(group && !suppressGroupTargetMsg) {
+            group->sendToAll(std::string("^g") + "<Group> " + ply->getName() + " is now targeting: " + std::string("^y") + toTarget->getCName() + "\n", ply, true, true);
+        }
     }
     hasTarget = true;
     return(lockedTarget);

--- a/creatures/monsters.cpp
+++ b/creatures/monsters.cpp
@@ -1022,7 +1022,7 @@ void Monster::checkScavange(long t) {
         return;
     
     // If already scavenged, might decide to drop!
-    if(flagIsSet(M_HAS_SCAVENGED) && countScavengedObjects() > 0) {
+    if(flagIsSet(M_HAS_SCAVENGED) && !flagIsSet(M_SCAVENGE_NO_DROP) && countScavengedObjects() > 0) {
         i = lasttime[LT_MON_SCAVENGE].ltime;
         if (t - i > 20 && Random::get<bool>(0.03) && room->mobCanDropObjects()) {
             scavengedObject = findScavengedObject();

--- a/groups/group.cpp
+++ b/groups/group.cpp
@@ -523,6 +523,8 @@ std::string Group::getFlagsDisplay() const {
     oStr << displayPref("Group Experience Split: ", flagIsSet(GROUP_SPLIT_EXPERIENCE));
     oStr << ", ";
     oStr << displayPref("Split Gold: ", flagIsSet(GROUP_SPLIT_GOLD));
+    oStr << ", ";
+    oStr << displayPref("Leader Ignore Gtarget: ", flagIsSet(LEADER_IGNORE_GTARGET));
     oStr << ".";
     return(oStr.str());
 }

--- a/groups/group.cpp
+++ b/groups/group.cpp
@@ -323,11 +323,13 @@ bool Group::inGroup(std::shared_ptr<Creature> target) {
 //********************************************************************************
 // Parameters: sendToInvited - Are invited members counted as in the group or not?
 // Send msg to everyone in the group except ignore
-void Group::sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore, bool sendToInvited) {
+void Group::sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore, bool sendToInvited, bool gtargetChange) {
     auto it = members.begin();
     while (it != members.end()) {
         if(auto crt = it->lock()) {
-            if(!crt->isPet() && crt != ignore && (sendToInvited || crt->getGroupStatus() >= GROUP_MEMBER )) {
+            if (!crt->isPet() && crt != ignore && 
+                (sendToInvited || crt->getGroupStatus() >= GROUP_MEMBER) &&
+                     !(gtargetChange && crt->flagIsSet(P_NO_GROUP_TARGET_MSG))) { 
                 *crt << ColorOn << msg << ColorOff;
             }
             it++;
@@ -607,7 +609,12 @@ std::string Group::getGroupList(const std::shared_ptr<Creature>& viewer) {
                     oStr << ", Wounded";
             }
 
-            oStr << ".";
+            oStr << " - ^gTargeting: ";
+            if(auto target = crt->myTarget.lock())
+                oStr << "^y" << target->getCName();
+            else
+                oStr << "^yNo-one!";
+            oStr << "^x";
         }
         oStr << "\n";
     }

--- a/groups/groups.cpp
+++ b/groups/groups.cpp
@@ -464,10 +464,7 @@ int Group::target(const std::shared_ptr<Player>& player, cmd* cmnd) {
     }
 
     if (std::string(cmnd->str[2]) == "-c") {
-
-        if (!group->flagIsSet(LEADER_IGNORE_GTARGET))
-            *player << ColorOn << "^gAll group member targets cleared.\n" << ColorOff;
-        
+        *player << ColorOn << "^gAll group member targets cleared." << (group->flagIsSet(LEADER_IGNORE_GTARGET)?" Your target was not cleared.":"") << "^x\n" << ColorOff;    
         group->clearTargets();
         return(0);
     }

--- a/include/flags.hpp
+++ b/include/flags.hpp
@@ -344,7 +344,7 @@
 #define P_BUILDER_OBJS              204      // Builder can make objs
 #define P_DARKMETAL                 205      // Player has a darkmetal item (DONT SET)
 #define P_SAVE_DEBUG                206
-// free                             207
+#define P_NO_GROUP_TARGET_MSG       207		 // Player will not see individual group targeting changes
 // free                             208
 // free                             209
 // free                             210
@@ -526,7 +526,7 @@
 #define M_NO_POISON                 166      // Monster cannot be poisoned
 #define M_NO_CHARM                  167      // Monster cannot be charmed
 #define M_SPECIAL_UNDEAD            168      // Monster turned as 'special' undead -- harder to turn
-// free                             169
+#define M_SCAVENGE_NO_DROP			169		 // Scavenging mob will not drop scavenged objects
 // free                             170
 // free                             171
 #define M_NO_EXP_LOSS               172      // Monster does not make player lose exp when they die

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -49,6 +49,7 @@ enum GroupFlags {
     GROUP_NO_FLAG = -1,
     GROUP_SPLIT_EXPERIENCE = 0,
     GROUP_SPLIT_GOLD,
+    LEADER_IGNORE_GTARGET,
 
     GROUP_MAX_FLAG
 };
@@ -65,6 +66,8 @@ public:
     static int reject(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int disband(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int promote(const std::shared_ptr<Player>& player, cmd* cmnd);
+    static int target(const std::shared_ptr<Player>& player, cmd* cmnd);
+    static int mtarget(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int kick(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int leave(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int rename(const std::shared_ptr<Player>& player, cmd* cmnd);
@@ -88,6 +91,7 @@ public:
     void setGroupType(GroupType newType);
     void setFlag(int flag);
     void clearFlag(int flag);
+    void clearTargets();
 
 
     // Various info about a group
@@ -108,7 +112,7 @@ public:
     std::string getGroupList(const std::shared_ptr<Creature>& viewer);
 
 
-    void sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore = nullptr, bool sendToInvited = false);
+    void sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore = nullptr, bool sendToInvited = false, bool gtargetChange=false);
 
     [[nodiscard]] std::string getMsdp(const std::shared_ptr<Creature>& viewer) const;
 

--- a/include/mudObjects/creatures.hpp
+++ b/include/mudObjects/creatures.hpp
@@ -269,7 +269,7 @@ public:
     bool hasAttackableTarget();
     bool isAttackingTarget();
     std::shared_ptr<Creature> getTarget();
-    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget);
+    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget,bool supressGroupTargetMsg=false);
     void checkTarget(const std::shared_ptr<Creature>& toTarget);
     void addTargetingThis(const std::shared_ptr<Creature>& targeter);
     void clearTarget(bool clearTargetsList = true);

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,7 +21,7 @@
 #define VERSION_MINOR "6"
 
 
-#define VERSION_SUB "2a"
+#define VERSION_SUB "2b"
 
 
 #define VERSION VERSION_MAJOR "." VERSION_MINOR VERSION_SUB

--- a/players/equipment.cpp
+++ b/players/equipment.cpp
@@ -2649,14 +2649,18 @@ int cmdGive(const std::shared_ptr<Creature>& creature, cmd* cmnd) {
         }
     }
 
-
-
     if(target->isPlayer()) {
-        if( target->isEffected("mist") &&
-            !player->checkStaff("How can you give something to a misted creature?\n")
-        )
+        if( target->isEffected("mist") && !player->checkStaff("How can you give something to a misted creature?\n"))
             return(0);
-    } else {
+
+        // Prevent using the @trash object filter for shenanigans. Force to give trash items individually.
+        if(std::string(cmnd->str[1]) == "@trash") {
+            player->printColor("You cannot give %M items using the ^c@trash^x filter.\n", target.get());
+            player->printColor("You need to give %P to %s without the filter.\n", object.get(),target->himHer());
+            return(0);
+        }
+    } 
+    else {
         if(target->flagIsSet(M_WILL_WIELD) && object->getType() == ObjectType::WEAPON) {
             player->print("%M doesn't want that.\n", target.get());
             return(0);

--- a/players/prefs.cpp
+++ b/players/prefs.cpp
@@ -106,6 +106,7 @@ prefInfo prefList[] =
 
     { "-Group",     0, nullptr, "", false },
     { "group",      P_IGNORE_GROUP_BROADCAST,nullptr,     "group combat messages",    true },
+    { "nogmtarget",   P_NO_GROUP_TARGET_MSG   ,nullptr,   "ignore group member targeting messages", false },
     { "xpsplit",    P_XP_DIVIDE,            nullptr,      "group experience split",   false },
     { "split",      P_GOLD_SPLIT,           nullptr,      "split gold among group",   false },
     { "stats",      P_NO_SHOW_STATS,        nullptr,      "show group your stats",    true },
@@ -333,6 +334,7 @@ int cmdPrefs(const std::shared_ptr<Player>& player, cmd* cmnd) {
             !player->flagIsSet(P_NO_SHOW_MAIL) ||
             !player->flagIsSet(P_NO_SHOW_MAIL) ||
             !player->flagIsSet(P_IGNORE_GROUP_BROADCAST) ||
+            !player->flagIsSet(P_NO_GROUP_TARGET_MSG) ||
             player->flagIsSet(P_PERM_DEATH) ||
             !player->flagIsSet(P_NO_AUCTIONS) ||
             !player->flagIsSet(P_HIDE_FORUM_POSTS)
@@ -380,6 +382,7 @@ int cmdPrefs(const std::shared_ptr<Player>& player, cmd* cmnd) {
             player->clearFlag(P_DONT_SHOW_SHOP_PROFITS);
             player->clearFlag(P_NO_SHOW_MAIL);
             player->clearFlag(P_IGNORE_GROUP_BROADCAST);
+            player->clearFlag(P_NO_GROUP_TARGET_MSG);
             player->setFlag(P_PERM_DEATH);
             player->clearFlag(P_NO_AUCTIONS);
             player->clearFlag(P_HIDE_FORUM_POSTS);
@@ -418,6 +421,7 @@ int cmdPrefs(const std::shared_ptr<Player>& player, cmd* cmnd) {
             player->setFlag(P_DONT_SHOW_SHOP_PROFITS);
             player->setFlag(P_NO_SHOW_MAIL);
             player->setFlag(P_IGNORE_GROUP_BROADCAST);
+            player->setFlag(P_NO_GROUP_TARGET_MSG);
             player->clearFlag(P_PERM_DEATH);
             player->setFlag(P_NO_AUCTIONS);
             player->setFlag(P_HIDE_FORUM_POSTS);


### PR DESCRIPTION
-Added group target and group mtarget
"group target (target|-c)" lets leader set or clear every group member's target
"group mtarget (group member) (target|-c)" lets leader set or clear individual group member targets
In both cases, group member must be in same room as leader to change targeting info
-Leader can "group set lgtignore" so their targets are not affected and remain independent. Defaults to off.
-Targeting information for each member now shows up in "group" output.
-Targeting changes by group members will now broadcast to group chat, unless a player has set "pref nogmtarget on" to suppress. This happens whether a group member is in same room as everybody else or not. Preference defaults to off.

-Made it so cannot use the @trash object filter when giving items to other players. I.e. "give @trash arikin" will not work.
-By default after last update 2.62a, all scavenging mobs have a chance to drop items too. Added a new mflag that can be set so they will still scavenge but will not drop items, same as prior to 2.62a.

-Bumped version to 2.62b.
