### PR TITLE
Gtarget and misc

### DIFF
--- a/combat/combat.cpp
+++ b/combat/combat.cpp
@@ -209,7 +209,7 @@ bool Monster::updateCombat() {
             if( pet->isPet() && getMaster() != pTarget && pet->getMaster() == pTarget && !pet->isEnemy(this) && pet.get() != this ) {
                 auto enemy = findFirstEnemyCrt(pet);
                 pet->addEnemy(enemy);
-                pTarget->print("%M jumps to your aid against %M!!\n", pet.get(), enemy.get());
+                pTarget->print("%M jumps to your aid against %N!!\n", pet.get(), enemy.get());
                 break;
             }
         }

--- a/combat/threat.cpp
+++ b/combat/threat.cpp
@@ -356,7 +356,7 @@ void Creature::checkTarget(const std::shared_ptr<Creature>& toTarget) {
 //                          addTarget
 //*********************************************************************
 
-std::shared_ptr<Creature> Creature::addTarget(const std::shared_ptr<Creature>& toTarget) {
+std::shared_ptr<Creature> Creature::addTarget(const std::shared_ptr<Creature>& toTarget, bool suppressGroupTargetMsg) {
     if(!toTarget)
         return(nullptr);
 
@@ -367,12 +367,19 @@ std::shared_ptr<Creature> Creature::addTarget(const std::shared_ptr<Creature>& t
 
     clearTarget();
 
+
     toTarget->addTargetingThis(Containable::downcasted_shared_from_this<Creature>());
     myTarget = toTarget;
 
     std::shared_ptr<Player> ply = getAsPlayer();
+    Group* group = getAsPlayer()->getGroup(true);
+
     if(ply) {
         ply->printColor("You are now targeting %s.\n", toTarget->getCName());
+
+        if(group && !suppressGroupTargetMsg) {
+            group->sendToAll(std::string("^g") + "<Group> " + ply->getName() + " is now targeting: " + std::string("^y") + toTarget->getCName() + "\n", ply, true, true);
+        }
     }
     hasTarget = true;
     return(lockedTarget);

--- a/creatures/monsters.cpp
+++ b/creatures/monsters.cpp
@@ -1022,7 +1022,7 @@ void Monster::checkScavange(long t) {
         return;
     
     // If already scavenged, might decide to drop!
-    if(flagIsSet(M_HAS_SCAVENGED) && countScavengedObjects() > 0) {
+    if(flagIsSet(M_HAS_SCAVENGED) && !flagIsSet(M_SCAVENGE_NO_DROP) && countScavengedObjects() > 0) {
         i = lasttime[LT_MON_SCAVENGE].ltime;
         if (t - i > 20 && Random::get<bool>(0.03) && room->mobCanDropObjects()) {
             scavengedObject = findScavengedObject();

--- a/groups/group.cpp
+++ b/groups/group.cpp
@@ -523,6 +523,8 @@ std::string Group::getFlagsDisplay() const {
     oStr << displayPref("Group Experience Split: ", flagIsSet(GROUP_SPLIT_EXPERIENCE));
     oStr << ", ";
     oStr << displayPref("Split Gold: ", flagIsSet(GROUP_SPLIT_GOLD));
+    oStr << ", ";
+    oStr << displayPref("Leader Ignore Gtarget: ", flagIsSet(LEADER_IGNORE_GTARGET));
     oStr << ".";
     return(oStr.str());
 }

--- a/groups/group.cpp
+++ b/groups/group.cpp
@@ -525,6 +525,8 @@ std::string Group::getFlagsDisplay() const {
     oStr << displayPref("Split Gold: ", flagIsSet(GROUP_SPLIT_GOLD));
     oStr << ", ";
     oStr << displayPref("Leader Ignore Gtarget: ", flagIsSet(LEADER_IGNORE_GTARGET));
+    oStr << ", ";
+    oStr << displayPref("Group Autotarget: ", flagIsSet(GROUP_AUTOTARGET));
     oStr << ".";
     return(oStr.str());
 }

--- a/groups/group.cpp
+++ b/groups/group.cpp
@@ -323,11 +323,13 @@ bool Group::inGroup(std::shared_ptr<Creature> target) {
 //********************************************************************************
 // Parameters: sendToInvited - Are invited members counted as in the group or not?
 // Send msg to everyone in the group except ignore
-void Group::sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore, bool sendToInvited) {
+void Group::sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore, bool sendToInvited, bool gtargetChange) {
     auto it = members.begin();
     while (it != members.end()) {
         if(auto crt = it->lock()) {
-            if(!crt->isPet() && crt != ignore && (sendToInvited || crt->getGroupStatus() >= GROUP_MEMBER )) {
+            if (!crt->isPet() && crt != ignore && 
+                (sendToInvited || crt->getGroupStatus() >= GROUP_MEMBER) &&
+                     !(gtargetChange && crt->flagIsSet(P_NO_GROUP_TARGET_MSG))) { 
                 *crt << ColorOn << msg << ColorOff;
             }
             it++;
@@ -607,7 +609,12 @@ std::string Group::getGroupList(const std::shared_ptr<Creature>& viewer) {
                     oStr << ", Wounded";
             }
 
-            oStr << ".";
+            oStr << " - ^gTargeting: ";
+            if(auto target = crt->myTarget.lock())
+                oStr << "^y" << target->getCName();
+            else
+                oStr << "^yNo-one!";
+            oStr << "^x";
         }
         oStr << "\n";
     }

--- a/groups/groups.cpp
+++ b/groups/groups.cpp
@@ -435,7 +435,7 @@ void Group::clearTargets() {
         if(auto gMember = it->lock()) {
             if(!gMember->isPlayer() || !gMember->inSameRoom(getLeader()) || (gMember->isStaff() && gMember != getLeader()))
                 continue;
-            if(gMember == getLeader() && (flagIsSet(LEADER_IGNORE_GTARGET) || flagIsSet(GROUP_AUTOTARGET)))
+            if(gMember == getLeader() && flagIsSet(LEADER_IGNORE_GTARGET))
                 continue;
             if(flagIsSet(GROUP_AUTOTARGET) && gMember->inCombat())
                 continue;
@@ -459,7 +459,7 @@ void Group::setTargets(const std::shared_ptr<Creature>& target, int ordinalNumbe
         if(auto gMember = it->lock()) {
             if(!gMember->isPlayer() || !gMember->inSameRoom(getLeader()) || (gMember->isStaff() && gMember != getLeader()))
                 continue;
-            if(gMember == getLeader() && (flagIsSet(LEADER_IGNORE_GTARGET) || flagIsSet(GROUP_AUTOTARGET)))
+            if(gMember == getLeader() && flagIsSet(LEADER_IGNORE_GTARGET))
                 continue;
             if(flagIsSet(GROUP_AUTOTARGET) && gMember->inCombat())
                 continue;
@@ -597,7 +597,7 @@ int Group::mtarget(const std::shared_ptr<Player>& player, cmd* cmnd) {
         << ((gMember->flagIsSet(P_NO_MTARGET_ORDINALS) || gMember->flagIsSet(P_NO_NUMBERS)) ? "" : (cmnd->val[3]>1?(getOrdinal(cmnd->val[3])+" "):"")) 
         << target->getCName() << "^x\n" << ColorOff;
 
-    gMember->addTarget(target,true, cmnd->val[3]);
+    gMember->addTarget(target,false, cmnd->val[3]);
 
     return(0);    
 }

--- a/groups/groups.cpp
+++ b/groups/groups.cpp
@@ -464,10 +464,7 @@ int Group::target(const std::shared_ptr<Player>& player, cmd* cmnd) {
     }
 
     if (std::string(cmnd->str[2]) == "-c") {
-
-        if (!group->flagIsSet(LEADER_IGNORE_GTARGET))
-            *player << ColorOn << "^gAll group member targets cleared.\n" << ColorOff;
-        
+        *player << ColorOn << "^gAll group member targets cleared." << (group->flagIsSet(LEADER_IGNORE_GTARGET)?" Your target was not cleared.":"") << "^x\n" << ColorOff;    
         group->clearTargets();
         return(0);
     }

--- a/groups/groups.cpp
+++ b/groups/groups.cpp
@@ -453,8 +453,6 @@ void Group::setTargets(const std::shared_ptr<Creature>& target, int ordinalNumbe
     if (!target)
         return;
 
-    std::string numString = (ordinalNumber > 1 ? " (" + std::to_string(ordinalNumber) + ")" : "");
-
     for(auto it = members.begin() ; it != members.end() ; it++) {
         if(auto gMember = it->lock()) {
             if(!gMember->isPlayer() || !gMember->inSameRoom(getLeader()) || (gMember->isStaff() && gMember != getLeader()))

--- a/include/flags.hpp
+++ b/include/flags.hpp
@@ -344,7 +344,7 @@
 #define P_BUILDER_OBJS              204      // Builder can make objs
 #define P_DARKMETAL                 205      // Player has a darkmetal item (DONT SET)
 #define P_SAVE_DEBUG                206
-// free                             207
+#define P_NO_GROUP_TARGET_MSG       207		 // Player will not see individual group targeting changes
 // free                             208
 // free                             209
 // free                             210
@@ -526,7 +526,7 @@
 #define M_NO_POISON                 166      // Monster cannot be poisoned
 #define M_NO_CHARM                  167      // Monster cannot be charmed
 #define M_SPECIAL_UNDEAD            168      // Monster turned as 'special' undead -- harder to turn
-// free                             169
+#define M_SCAVENGE_NO_DROP			169		 // Scavenging mob will not drop scavenged objects
 // free                             170
 // free                             171
 #define M_NO_EXP_LOSS               172      // Monster does not make player lose exp when they die

--- a/include/flags.hpp
+++ b/include/flags.hpp
@@ -345,7 +345,7 @@
 #define P_DARKMETAL                 205      // Player has a darkmetal item (DONT SET)
 #define P_SAVE_DEBUG                206
 #define P_NO_GROUP_TARGET_MSG       207		 // Player will not see individual group targeting changes
-// free                             208
+#define P_NO_MTARGET_ORDINALS   208		 // Player will not see monster ordinals in group target messages
 // free                             209
 // free                             210
 // free                             211

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -49,6 +49,7 @@ enum GroupFlags {
     GROUP_NO_FLAG = -1,
     GROUP_SPLIT_EXPERIENCE = 0,
     GROUP_SPLIT_GOLD,
+    LEADER_IGNORE_GTARGET,
 
     GROUP_MAX_FLAG
 };
@@ -65,6 +66,8 @@ public:
     static int reject(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int disband(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int promote(const std::shared_ptr<Player>& player, cmd* cmnd);
+    static int target(const std::shared_ptr<Player>& player, cmd* cmnd);
+    static int mtarget(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int kick(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int leave(const std::shared_ptr<Player>& player, cmd* cmnd);
     static int rename(const std::shared_ptr<Player>& player, cmd* cmnd);
@@ -88,6 +91,7 @@ public:
     void setGroupType(GroupType newType);
     void setFlag(int flag);
     void clearFlag(int flag);
+    void clearTargets();
 
 
     // Various info about a group
@@ -108,7 +112,7 @@ public:
     std::string getGroupList(const std::shared_ptr<Creature>& viewer);
 
 
-    void sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore = nullptr, bool sendToInvited = false);
+    void sendToAll(std::string_view msg, const std::shared_ptr<Creature>& ignore = nullptr, bool sendToInvited = false, bool gtargetChange=false);
 
     [[nodiscard]] std::string getMsdp(const std::shared_ptr<Creature>& viewer) const;
 

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -50,6 +50,7 @@ enum GroupFlags {
     GROUP_SPLIT_EXPERIENCE = 0,
     GROUP_SPLIT_GOLD,
     LEADER_IGNORE_GTARGET,
+    GROUP_AUTOTARGET,
 
     GROUP_MAX_FLAG
 };
@@ -92,6 +93,7 @@ public:
     void setFlag(int flag);
     void clearFlag(int flag);
     void clearTargets();
+    void setTargets(const std::shared_ptr<Creature>& target, int ordinalNumber=0);
 
 
     // Various info about a group

--- a/include/mudObjects/creatures.hpp
+++ b/include/mudObjects/creatures.hpp
@@ -269,7 +269,7 @@ public:
     bool hasAttackableTarget();
     bool isAttackingTarget();
     std::shared_ptr<Creature> getTarget();
-    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget);
+    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget,bool supressGroupTargetMsg=false);
     void checkTarget(const std::shared_ptr<Creature>& toTarget);
     void addTargetingThis(const std::shared_ptr<Creature>& targeter);
     void clearTarget(bool clearTargetsList = true);

--- a/include/mudObjects/creatures.hpp
+++ b/include/mudObjects/creatures.hpp
@@ -269,7 +269,7 @@ public:
     bool hasAttackableTarget();
     bool isAttackingTarget();
     std::shared_ptr<Creature> getTarget();
-    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget,bool supressGroupTargetMsg=false);
+    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget,bool supressGroupTargetMsg=false,int ordinalNumber=0);
     void checkTarget(const std::shared_ptr<Creature>& toTarget);
     void addTargetingThis(const std::shared_ptr<Creature>& targeter);
     void clearTarget(bool clearTargetsList = true);

--- a/include/mudObjects/creatures.hpp
+++ b/include/mudObjects/creatures.hpp
@@ -269,7 +269,7 @@ public:
     bool hasAttackableTarget();
     bool isAttackingTarget();
     std::shared_ptr<Creature> getTarget();
-    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget,bool supressGroupTargetMsg=false,int ordinalNumber=0);
+    std::shared_ptr<Creature> addTarget(const std::shared_ptr<Creature>& toTarget,bool supressGroupTargetMsg=true,int ordinalNumber=0);
     void checkTarget(const std::shared_ptr<Creature>& toTarget);
     void addTargetingThis(const std::shared_ptr<Creature>& targeter);
     void clearTarget(bool clearTargetsList = true);

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,7 +21,7 @@
 #define VERSION_MINOR "6"
 
 
-#define VERSION_SUB "2a"
+#define VERSION_SUB "2b"
 
 
 #define VERSION VERSION_MAJOR "." VERSION_MINOR VERSION_SUB

--- a/players/equipment.cpp
+++ b/players/equipment.cpp
@@ -2649,14 +2649,18 @@ int cmdGive(const std::shared_ptr<Creature>& creature, cmd* cmnd) {
         }
     }
 
-
-
     if(target->isPlayer()) {
-        if( target->isEffected("mist") &&
-            !player->checkStaff("How can you give something to a misted creature?\n")
-        )
+        if( target->isEffected("mist") && !player->checkStaff("How can you give something to a misted creature?\n"))
             return(0);
-    } else {
+
+        // Prevent using the @trash object filter for shenanigans. Force to give trash items individually.
+        if(std::string(cmnd->str[1]) == "@trash") {
+            player->printColor("You cannot give %M items using the ^c@trash^x filter.\n", target.get());
+            player->printColor("You need to give %P to %s without the filter.\n", object.get(),target->himHer());
+            return(0);
+        }
+    } 
+    else {
         if(target->flagIsSet(M_WILL_WIELD) && object->getType() == ObjectType::WEAPON) {
             player->print("%M doesn't want that.\n", target.get());
             return(0);

--- a/players/prefs.cpp
+++ b/players/prefs.cpp
@@ -103,6 +103,7 @@ prefInfo prefList[] =
     { "mobnums",    P_NO_NUMBERS,           nullptr,      "monster ordinal numbers",  true },
     { "autotarget", P_NO_AUTO_TARGET,       nullptr,      "automatic targeting",      true },
     { "fleetarget", P_CLEAR_TARGET_ON_FLEE, nullptr,      "clear target on flee",     false },
+    { "notargetnumbers",  P_NO_MTARGET_ORDINALS, nullptr, "no monster ordinals in targeting", false},
 
     { "-Group",     0, nullptr, "", false },
     { "group",      P_IGNORE_GROUP_BROADCAST,nullptr,     "group combat messages",    true },
@@ -111,6 +112,7 @@ prefInfo prefList[] =
     { "split",      P_GOLD_SPLIT,           nullptr,      "split gold among group",   false },
     { "stats",      P_NO_SHOW_STATS,        nullptr,      "show group your stats",    true },
     { "follow",     P_NO_FOLLOW,            nullptr,      "can be followed",          true },
+
 
     { "-Display",   0, nullptr, "", false },
     { "showall",    P_SHOW_ALL_PREFS,       nullptr,      "show all preferences",     false },

--- a/players/prefs.cpp
+++ b/players/prefs.cpp
@@ -106,6 +106,7 @@ prefInfo prefList[] =
 
     { "-Group",     0, nullptr, "", false },
     { "group",      P_IGNORE_GROUP_BROADCAST,nullptr,     "group combat messages",    true },
+    { "nogmtarget",   P_NO_GROUP_TARGET_MSG   ,nullptr,   "ignore group member targeting messages", false },
     { "xpsplit",    P_XP_DIVIDE,            nullptr,      "group experience split",   false },
     { "split",      P_GOLD_SPLIT,           nullptr,      "split gold among group",   false },
     { "stats",      P_NO_SHOW_STATS,        nullptr,      "show group your stats",    true },
@@ -333,6 +334,7 @@ int cmdPrefs(const std::shared_ptr<Player>& player, cmd* cmnd) {
             !player->flagIsSet(P_NO_SHOW_MAIL) ||
             !player->flagIsSet(P_NO_SHOW_MAIL) ||
             !player->flagIsSet(P_IGNORE_GROUP_BROADCAST) ||
+            !player->flagIsSet(P_NO_GROUP_TARGET_MSG) ||
             player->flagIsSet(P_PERM_DEATH) ||
             !player->flagIsSet(P_NO_AUCTIONS) ||
             !player->flagIsSet(P_HIDE_FORUM_POSTS)
@@ -380,6 +382,7 @@ int cmdPrefs(const std::shared_ptr<Player>& player, cmd* cmnd) {
             player->clearFlag(P_DONT_SHOW_SHOP_PROFITS);
             player->clearFlag(P_NO_SHOW_MAIL);
             player->clearFlag(P_IGNORE_GROUP_BROADCAST);
+            player->clearFlag(P_NO_GROUP_TARGET_MSG);
             player->setFlag(P_PERM_DEATH);
             player->clearFlag(P_NO_AUCTIONS);
             player->clearFlag(P_HIDE_FORUM_POSTS);
@@ -418,6 +421,7 @@ int cmdPrefs(const std::shared_ptr<Player>& player, cmd* cmnd) {
             player->setFlag(P_DONT_SHOW_SHOP_PROFITS);
             player->setFlag(P_NO_SHOW_MAIL);
             player->setFlag(P_IGNORE_GROUP_BROADCAST);
+            player->setFlag(P_NO_GROUP_TARGET_MSG);
             player->clearFlag(P_PERM_DEATH);
             player->setFlag(P_NO_AUCTIONS);
             player->setFlag(P_HIDE_FORUM_POSTS);


### PR DESCRIPTION
Added a lot of functionality around the group command.
So long as group members are in the same room, group members can now set all group members' targets.
They can also set individual group members targets.

In addition, there is now a new group flag called "autotarget" which when on, it makes the entire group follow the leader's "target" commands, setting or clearing, so long as in the same room as the leader, and NOT already in combat.

Target will also now show mob ordinal numbers in the output. This could screw some people's triggers up, so also added new player preference "notargetnumbers" which defaults to off. It can be switched on, and the ordinal numbers will not show up and the output will act just as it always has acted.