### PR TITLE
Account_Fixes2

### DIFF
--- a/accounts/account.cpp
+++ b/accounts/account.cpp
@@ -32,6 +32,7 @@
 #include "server.hpp"
 #include "xml.hpp"
 #include "config.hpp"
+#include "proto.hpp"
 
 namespace fs = std::filesystem;
 
@@ -365,24 +366,25 @@ bool Account::isValidPassword(const std::string& password) {
 
 void Account::printInfoFields(const std::shared_ptr<Player>& player) const {
     if(!player) return;
-    player->print("^W%-12s^C%s^x\n", "Account:", getName().c_str());
+    player->print("^W%-20s^C%s^x\n", "Account:", getName().c_str());
     if(!getEmail().empty()) {
-        player->print("^W%-12s^x%s\n", "Email:", getEmail().c_str());
+        player->print("^W%-20s^x%s\n", "Email:", getEmail().c_str());
     }
-    player->print("^W%-12s^x%d/%d\n", "Characters:", getCharacterCount(), getCharacterLimit());
-    player->print("^W%-12s^G%llu^x\n", "Exp Earned:", getExpEarned());
-    player->print("^W%-12s^G%llu^x\n\n", "Exp Spent:", getExpSpent());
+    player->print("^W%-20s^x%d/%d\n", "Characters:", getCharacterCount(), getCharacterLimit());
+
+    player->print("^W%-20s^G%s^x\n","Legacy XP Earned: ",commaNum(getExpEarned()).c_str());
+    player->print("^W%-20s^G%s^x\n\n","Legacy XP Spent: ",commaNum(getExpSpent()).c_str());
 }
 
 void Account::printInfoFields(const std::shared_ptr<Socket>& sock) const {
     if(!sock) return;
-    sock->print("^W%-12s^C%s^x\n", "Account:", getName().c_str());
+    sock->print("^W%-20s^C%s^x\n", "Account:", getName().c_str());
     if(!getEmail().empty()) {
-        sock->print("^W%-12s^x%s\n", "Email:", getEmail().c_str());
+        sock->print("^W%-20s^x%s\n", "Email:", getEmail().c_str());
     }
-    sock->print("^W%-12s^x%d/%d\n", "Characters:", getCharacterCount(), getCharacterLimit());
-    sock->print("^W%-12s^G%llu^x\n", "Exp Earned:", getExpEarned());
-    sock->print("^W%-12s^G%llu^x\n\n", "Exp Spent:", getExpSpent());
+    sock->print("^W%-20s^x%d/%d\n", "Characters:", getCharacterCount(), getCharacterLimit());
+    sock->print("^W%-20s^G%s^x\n","Legacy XP Earned: ",commaNum(getExpEarned()).c_str());
+    sock->print("^W%-20s^G%s^x\n\n","Legacy XP Spent: ",commaNum(getExpSpent()).c_str());
 }
 
 void Account::printCharacterList(const std::shared_ptr<Player>& player) const {

--- a/creatures/creatureAttr.cpp
+++ b/creatures/creatureAttr.cpp
@@ -160,7 +160,7 @@ void Creature::addExperience(unsigned long e) {
                 double accountExpDouble = e * 0.01;
                 unsigned long accountExp = static_cast<unsigned long>(accountExpDouble + 0.5);
                 if(accountExp > 0) {
-                    account->addExp(e);
+                    account->addExp(accountExp);
                 }
             }
         }

--- a/include/proto.hpp
+++ b/include/proto.hpp
@@ -23,6 +23,9 @@
 
 #include "structs.hpp"
 
+#include <sstream>
+#include <locale>
+
 namespace fs = std::filesystem;
 
 class cmd;
@@ -130,11 +133,13 @@ void link_rom(const std::shared_ptr<BaseRoom> &room, const MapMarker& mapmarker,
 
 int room_track(const std::shared_ptr<Creature>& player);
 
-
-
-
-
-
+template<typename T>
+std::string commaNum(T value) {
+    std::stringstream oStr;
+    oStr.imbue(std::locale(""));
+    oStr << value;
+    return oStr.str();
+}
 
 // access.cp
 std::string intToText(int nNumber, bool cap=false);

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,7 +21,7 @@
 #define VERSION_MINOR "6"
 
 
-#define VERSION_SUB "3"
+#define VERSION_SUB "3a"
 
 
 #define VERSION VERSION_MAJOR "." VERSION_MINOR VERSION_SUB

--- a/util/misc.cpp
+++ b/util/misc.cpp
@@ -36,6 +36,7 @@
 #include <string_view>                           // for string_view, basic_s...
 #include <utility>                               // for pair
 
+
 #include "catRef.hpp"                            // for CatRef
 #include "config.hpp"                            // for Config, gConfig
 #include "flags.hpp"                             // for P_STUNNED
@@ -61,6 +62,7 @@
 
 #include <boost/algorithm/string.hpp>            // split, join
 
+
 class MudObject;
 
 bool isClass(std::string_view str);
@@ -71,6 +73,8 @@ bool partialMatch(const std::string& got, const char* full, size_t maxLen) {
     if(n < 1) return false;
     return ::strncasecmp(got.c_str(), full, n) == 0;
 }
+
+
 
 //*********************************************************************
 //                      validId functions


### PR DESCRIPTION
-Fixed typo bug in Creature::addExperience() which was giving full XP value to Account XP rather than only the 1% as intended 
-Renamed "Account XP" to "Legacy XP" as was planned initially. Changed that accordingly in account info printout. 
-Added comma formatting to account/legacy XP printout