### PR TITLE
Fix DM account character creation and third-party warning noise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,20 @@ FetchContent_Declare(googletest  GIT_REPOSITORY https://github.com/google/google
 FetchContent_MakeAvailable(pybind11 fmt nlohmann_json crow dpp jwt-cpp googletest)
 set(FMT_INCLUDE_DIR "${FMT_SOURCE_DIR}/${FMT_INC_DIR}")
 
+set(REALMS_THIRD_PARTY_CLANG_WARNING_SUPPRESSIONS
+    $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wno-deprecated-literal-operator>
+)
+
+if(TARGET dpp)
+    target_compile_options(dpp PRIVATE ${REALMS_THIRD_PARTY_CLANG_WARNING_SUPPRESSIONS})
+endif()
+
+# nlohmann_json is header-only, so the suppression must be attached to its
+# interface target to cover warnings emitted while consumers parse its headers.
+if(TARGET nlohmann_json)
+    target_compile_options(nlohmann_json INTERFACE ${REALMS_THIRD_PARTY_CLANG_WARNING_SUPPRESSIONS})
+endif()
+
 include_directories(${PYTHON_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR} ${PYBIND11_INCLUDE_DIR} ${FMT_INCLUDE_DIR} "include")
 
 SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -g" )

--- a/creatures/creatureSkills.cpp
+++ b/creatures/creatureSkills.cpp
@@ -16,10 +16,51 @@
  *
  */
 
+#include <sstream>                          // for ostringstream
+#include <string>                           // for string, to_string
+
 #include "config.hpp"                       // for Config, gConfig
+#include "deityData.hpp"                    // for DeityData
 #include "mudObjects/creatures.hpp"         // for Creature, PetList
+#include "proto.hpp"                        // for broadcast, isDm, loge
+#include "raceData.hpp"                     // for RaceData
 #include "skillGain.hpp"                    // for SkillGain
 #include "login.hpp"                       // for addStartingWeapon
+
+namespace {
+
+const SkillInfo* getInitialWeaponSkillInfo(const Creature* creature, const SkillGain* sGain, const char* functionName, const char* source) {
+    const SkillInfo* skill = gConfig->getSkill(sGain->getName());
+    if(skill)
+        return(skill);
+
+    std::ostringstream context;
+    context << "source=" << source
+            << ", class=" << (creature ? creature->getClassString() : "<unknown>");
+
+    if(creature && creature->getRace()) {
+        const RaceData* race = gConfig->getRace(creature->getRace());
+        context << ", race=" << (race ? race->getName() : std::to_string(creature->getRace()));
+    } else {
+        context << ", race=<none>";
+    }
+
+    if(creature && creature->getDeity()) {
+        const DeityData* deity = gConfig->getDeity(creature->getDeity());
+        context << ", deity=" << (deity ? deity->getName() : std::to_string(creature->getDeity()));
+    } else {
+        context << ", deity=<none>";
+    }
+
+    const std::string message = "Bad config: " + std::string(functionName) +
+                                " missing skill '" + sGain->getName() + "' (" +
+                                context.str() + ")";
+    loge("%s\n", message.c_str());
+    broadcast(isDm, "^G%s^x", message.c_str());
+    return(nullptr);
+}
+
+}
 
 //*********************************************************************
 //                      checkSkillsGain
@@ -55,9 +96,9 @@ void Creature::getInitialRaceWeaponSkills(const std::list<SkillGain*>::const_ite
         sGain = (*sgIt);
         if(sGain->getName().empty())
             continue;
-      const SkillInfo* skill = gConfig->getSkill(sGain->getName());
-      if (!skill->getGroup().starts_with("weapons"))
-           continue;
+        const SkillInfo* skill = getInitialWeaponSkillInfo(this, sGain, __func__, "race");
+        if (!skill || !skill->getGroup().starts_with("weapons"))
+            continue;
 
         num++;
         if (num == 1)
@@ -87,8 +128,8 @@ void Creature::getInitialClassWeaponSkills(const std::list<SkillGain*>::const_it
         sGain = (*sgIt);
         if(sGain->getName().empty())
             continue;
-        const SkillInfo* skill = gConfig->getSkill(sGain->getName());
-        if (!skill->getGroup().starts_with("weapons"))
+        const SkillInfo* skill = getInitialWeaponSkillInfo(this, sGain, __func__, "class");
+        if (!skill || !skill->getGroup().starts_with("weapons"))
            continue;
 
         if (knowsSkill(sGain->getName()) || (deity && !sGain->deityIsAllowed(deity)))
@@ -114,4 +155,3 @@ void Creature::getInitialClassWeaponSkills(const std::list<SkillGain*>::const_it
     initSkillString = sStr.str();
     return;
 }
-

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,7 +21,7 @@
 #define VERSION_MINOR "6"
 
 
-#define VERSION_SUB "3a"
+#define VERSION_SUB "3b"
 
 
 #define VERSION VERSION_MAJOR "." VERSION_MINOR VERSION_SUB

--- a/server/login.cpp
+++ b/server/login.cpp
@@ -908,21 +908,8 @@ void createPlayer(std::shared_ptr<Socket> sock, const std::string& str) {
 
             target->defineColors();
         }
-        if(isdm(sock->tempstr[0])) {
-            sock->print("\nYou must enter a password to create that character.\n");
-            sock->print("Please enter password: ");
-            gServer->processOutput();
-            sock->setState(CREATE_GET_DM_PASSWORD);
-            return;
-        } else
-            goto no_pass;
+        goto no_pass;
         // End CREATE_NEW_CHARACTER
-    case CREATE_GET_DM_PASSWORD:
-        if(str != gConfig->getDmPass()) {
-            sock->disconnect();
-            return;
-        }
-
     case CREATE_CHECK_LOCKED_OUT:
 no_pass:
         if(gConfig->isLockedOut(sock) == 1) {
@@ -1046,6 +1033,22 @@ no_pass:
 
         if(!Create::getName(sock, str, Create::doWork))
             return;
+        if(isdm(sock->tempstr[0])) {
+            sock->print("\nYou must enter a password to create that character.\n");
+            sock->print("%s", echo_off);
+            sock->askFor("Please enter password: ");
+            sock->setState(CREATE_GET_DM_PASSWORD);
+            return;
+        }
+        Create::done(sock, str, Create::doPrint);
+        return;
+
+    case CREATE_GET_DM_PASSWORD:
+        sock->print("%s", echo_on);
+        if(str != gConfig->getDmPass()) {
+            sock->disconnect();
+            return;
+        }
         Create::done(sock, str, Create::doPrint);
         return;
 


### PR DESCRIPTION
- Move DM password check during character creation to the chosen character name step
- Allow DM-named accounts to start normal account character creation
- Suppress Clang deprecated literal operator warnings only for DPP/nlohmann targets
- Guard initial race/class weapon skill grants against missing skill config entries
- Report missing initial skill config to server log and DMs, then skip the bad skill
- Bump version to 2.63b